### PR TITLE
Fix non-responsive state (Take 2)

### DIFF
--- a/src/toolbar/toolbar-controller.js
+++ b/src/toolbar/toolbar-controller.js
@@ -15,11 +15,6 @@
             this.window = null;
             this.maximised = false;
             this.oldSize = null;
-            currentWindowService.ready(() => {
-                var boundReady = this.onReady.bind(this);
-                boundReady();
-                this._watch();
-            });
 
             this.maximisedEvent = () => {
                 this.$timeout(() => {
@@ -32,6 +27,12 @@
                     this.maximised = false;
                 });
             };
+
+            currentWindowService.ready(() => {
+                var boundReady = this.onReady.bind(this);
+                boundReady();
+                this._watch();
+            });
         }
 
         isCompact() {


### PR DESCRIPTION
#508 
this.maximisedEvent etc were bound after the ready event was bound, meaning that the listener callbacks weren't defined if OpenFin was already ready.
