### PR TITLE
Change closed windows icon when closed a window

### DIFF
--- a/src/closedWindows/closedWindowList/closedWindowList-controller.js
+++ b/src/closedWindows/closedWindowList/closedWindowList-controller.js
@@ -7,8 +7,13 @@
             this.$timeout = $timeout;
             this.closedWindows = [];
             this.closedTabsShow = false;
+            this.overriddenIcon = '';
 
             this._watch();
+        }
+
+        override() {
+            return this.overriddenIcon;
         }
 
         refreshClosedWindows() {
@@ -16,6 +21,7 @@
         }
 
         click() {
+            this.overriddenIcon = '';
             this.refreshClosedWindows();
             this.closedTabsShow = this.closedWindows.length > 0;
         }
@@ -38,6 +44,10 @@
 
             this.$scope.$on('$destroy', () => {
                 window.windowService.removeClosedWindowListener(listener);
+            });
+
+            this.$scope.$on('windowClosed', () => {
+                this.overriddenIcon = this.$scope.icon + '_active';
             });
         }
     }

--- a/src/closedWindows/closedWindowList/closedWindowList.html
+++ b/src/closedWindows/closedWindowList/closedWindowList.html
@@ -1,6 +1,6 @@
 <div ng-if="closedWindowListCtrl.closedWindows.length !== 0">
     <div class="favourite-closed">
-        <icon name="{{icon}}" icon-click="closedWindowListCtrl.click(); $event.stopPropagation();" tooltip="Last Closed Windows"></icon>
+        <icon name="{{icon}}" override="{{closedWindowListCtrl.override()}}" icon-click="closedWindowListCtrl.click(); $event.stopPropagation();" tooltip="Last Closed Windows"></icon>
     </div>
     <div ng-show="closedWindowListCtrl.closedTabsShow" class="favourite-closed-cover" ng-click="closedWindowListCtrl.closedTabsShow = false">
         <div class="bubble-head"></div>

--- a/src/icon/icon-controller.js
+++ b/src/icon/icon-controller.js
@@ -22,7 +22,12 @@
         }
 
         url() {
-            return this.active ? this.urls.active : this.urls.inactive;
+            var override = this.$scope.override;
+            if (override) {
+                return override;
+            } else {
+                return this.active ? this.urls.active : this.urls.inactive;
+            }
         }
 
         click(e) {

--- a/src/icon/icon-directive.js
+++ b/src/icon/icon-directive.js
@@ -9,7 +9,8 @@
                 scope: {
                     name: '@',
                     iconClick: '&',
-                    tooltip: '@'
+                    tooltip: '@',
+                    override: '@'
                 },
                 controller: 'IconCtrl',
                 controllerAs: 'iconCtrl'

--- a/src/parent-controller.js
+++ b/src/parent-controller.js
@@ -29,6 +29,13 @@
                     var openWindow = windowCreationService.getWindow(windowName);
                     openWindow.getNativeWindow().dispatchEvent(e);
                 });
+
+                $scope.$on('windowClosed', () => {
+                    var e = new Event('windowClosed');
+                    windowCreationService.getMainWindows().forEach((mw) => {
+                        mw.getNativeWindow().dispatchEvent(e);
+                    });
+                });
             });
         }
     }

--- a/src/services/currentWindow-service.js
+++ b/src/services/currentWindow-service.js
@@ -25,6 +25,10 @@
                 $rootScope.$broadcast('updateFavourites', event.stock);
             });
 
+            window.addEventListener('windowClosed', () => {
+                $rootScope.$broadcast('windowClosed');
+            });
+
             return {
                 getCurrentWindow: getCurrentWindow,
                 openUrlWithBrowser: openUrlWithBrowser,

--- a/src/window-service.js
+++ b/src/window-service.js
@@ -215,6 +215,7 @@
      */
     class WindowCreationService {
         constructor($rootScope, storeService, geometryService, $q, configService) {
+            this.$rootScope = $rootScope;
             this.storeService = storeService;
             this.geometryService = geometryService;
             this.$q = $q;
@@ -273,6 +274,7 @@
             var closedEvent = (e) => {
                 this.windowTracker.dispose(mainWindow, () => {
                     this.storeService.open(mainWindow.name).closeWindow();
+                    this.$rootScope.$broadcast('windowClosed');
                     mainWindow.removeEventListener('closed', closedEvent);
                 });
             };
@@ -374,9 +376,14 @@
             fin.desktop.main(cb);
         }
 
-        getWindow(name) {
-            return this.windowTracker.getMainWindows().filter((w) => w.name === name)[0];
+        getMainWindows() {
+            return this.windowTracker.getMainWindows();
         }
+
+        getWindow(name) {
+            return this.getMainWindows().filter((w) => w.name === name)[0];
+        }
+
 
         registerDrag(tearoutWindow, openFinWindow) {
             return new DragService(
@@ -393,3 +400,4 @@
     angular.module('stockflux.window')
         .service('windowCreationService', WindowCreationService);
 }(fin));
+


### PR DESCRIPTION
This PR introduces the feature whereby all closed windows icons are toggled to active when any app window is closed.

When one of these icons is then opened to view the new closed window it will revert back to the default behaviour. However, the closed window icons in any and all other app instances will remain active -- this is left as a todo for a future PR.