### PR TITLE
Save version in Local Storage

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -178,7 +178,7 @@ module.exports = function(grunt) {
             parent: {
                 src: ['src/parentApp.js', 'src/parent-controller.js', 'src/store-service.js',
                     'src/window-service.js', 'src/sidebars/favourites/geometry-service.js',
-                    'src/config-service.js'],
+                    'src/config-service.js', 'src/main/version/version-controller.js'],
                 dest: 'public/app-parent.js'
             }
         },

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -178,7 +178,7 @@ module.exports = function(grunt) {
             parent: {
                 src: ['src/parentApp.js', 'src/parent-controller.js', 'src/store-service.js',
                     'src/window-service.js', 'src/sidebars/favourites/geometry-service.js',
-                    'src/config-service.js', 'src/main/version/version-controller.js'],
+                    'src/config-service.js', 'src/version-value.js'],
                 dest: 'public/app-parent.js'
             }
         },
@@ -203,13 +203,11 @@ module.exports = function(grunt) {
         },
         bump: {
             options: {
-                files: ['package.json', 'src/main/version/version-controller.js'],
+                files: ['package.json', 'src/version-value.js'],
                 commit: true,
-                commitMessage: 'Release v%VERSION%',
-                commitFiles: ['package.json', 'src/main/version/version-controller.js'],
-                createTag: true,
-                tagName: 'v%VERSION%',
-                tagMessage: 'Version %VERSION%',
+                commitMessage: 'Release %VERSION%',
+                commitFiles: ['package.json', 'src/version-value.js'],
+                createTag: false,
                 push: false
             }
         },

--- a/src/main/version/version-controller.js
+++ b/src/main/version/version-controller.js
@@ -1,24 +1,18 @@
 (function() {
     'use strict';
 
-    const VERSION = { version: '9.2.0' };
-
     class VersionCtrl {
-        constructor(currentWindowService) {
+        constructor(currentWindowService, version) {
             this.currentWindowService = currentWindowService;
-        }
-
-        version() {
-            return VERSION.version;
+            this.version = version;
         }
 
         openGithub() {
             this.currentWindowService.openUrlWithBrowser('https://github.com/ScottLogic/stockflux');
         }
     }
-    VersionCtrl.$inject = ['currentWindowService'];
+    VersionCtrl.$inject = ['currentWindowService', 'Version'];
 
     angular.module('stockflux.version')
-        .value('Version', VERSION.version)
         .controller('VersionCtrl', VersionCtrl);
 }());

--- a/src/main/version/version-controller.js
+++ b/src/main/version/version-controller.js
@@ -19,5 +19,6 @@
     VersionCtrl.$inject = ['currentWindowService'];
 
     angular.module('stockflux.version')
+        .value('Version', VERSION.version)
         .controller('VersionCtrl', VersionCtrl);
 }());

--- a/src/main/version/version.html
+++ b/src/main/version/version.html
@@ -1,1 +1,1 @@
-﻿<a class="version" ng-click="versionCtrl.openGithub()">GitHub {{versionCtrl.version()}}</a>
+﻿<a class="version" ng-click="versionCtrl.openGithub()">GitHub {{versionCtrl.version}}</a>

--- a/src/parent-controller.js
+++ b/src/parent-controller.js
@@ -6,6 +6,13 @@
      */
     class ParentCtrl {
         constructor($scope, storeService, windowCreationService) {
+
+            if (storeService.shouldUpgrade()) {
+                storeService.upgrade();
+                // .. Can put other upgrade code here ..
+                storeService.saveVersion();
+            }
+
             windowCreationService.ready(() => {
                 var previousWindows = storeService.getPreviousOpenWindowNames(),
                     length = previousWindows.length,

--- a/src/parentApp.js
+++ b/src/parentApp.js
@@ -6,7 +6,8 @@
     ]);
 
     angular.module('stockflux.parent', ['stockflux.store', 'stockflux.window']);
-    angular.module('stockflux.store', []);
+    angular.module('stockflux.store', ['stockflux.version']);
+    angular.module('stockflux.version', []);
     angular.module('stockflux.currentWindow', []);
     angular.module('stockflux.window', ['stockflux.store', 'stockflux.geometry', 'stockflux.config']);
     angular.module('stockflux.config', []);

--- a/src/store-service.js
+++ b/src/store-service.js
@@ -1,7 +1,8 @@
 (function() {
     'use strict';
 
-    const KEY_NAME = 'windows',
+    const WINDOW_KEY = 'windows',
+        VERSION_KEY = 'version',
         defaultStocks = ['AAPL', 'MSFT', 'TITN', 'SNDK', 'TSLA'],
         defaultIndicators = ['rsi', 'movingAverage'],
         closedCacheSize = 5;
@@ -19,7 +20,7 @@
         }
 
         save() {
-            localStorage.setItem(KEY_NAME, angular.toJson(storage));
+            localStorage.setItem(WINDOW_KEY, angular.toJson(storage));
         }
 
         update(stock) {
@@ -114,9 +115,35 @@
      * Class for querying and managing the local storage.
      */
     class StoreService {
-        constructor($rootScope) {
+        constructor($rootScope, version) {
             this.$rootScope = $rootScope;
-            storage = JSON.parse(localStorage.getItem(KEY_NAME));
+            this.version = version;
+
+            storage = JSON.parse(localStorage.getItem(WINDOW_KEY));
+        }
+
+        shouldUpgrade() {
+            if (localStorage.getItem(VERSION_KEY) == null) {
+                return true;
+            }
+            var parseVersion = (version) => version.split('.').map((v) => Number(v));
+            var thisVersion = parseVersion(this.version);
+            var storedVersion = parseVersion(localStorage.getItem(VERSION_KEY));
+
+            // If there's more than x.y.z, someone's probably tampered.
+            if (storedVersion.length > 3) {
+                return true;
+            }
+            return thisVersion[0] !== storedVersion[0];
+        }
+
+        upgrade() {
+            localStorage.removeItem(WINDOW_KEY);
+            storage = null;
+        }
+
+        saveVersion() {
+            localStorage.setItem(VERSION_KEY, this.version);
         }
 
         getPreviousOpenWindowNames() {
@@ -162,7 +189,7 @@
             return new StoreWrapper(this.$rootScope, store, windowName);
         }
     }
-    StoreService.$inject = ['$rootScope'];
+    StoreService.$inject = ['$rootScope', 'Version'];
 
     angular.module('stockflux.store')
         .service('storeService', StoreService);

--- a/src/version-value.js
+++ b/src/version-value.js
@@ -1,0 +1,8 @@
+(function() {
+    'use strict';
+
+    const VERSION = { version: '9.2.0' };
+
+    angular.module('stockflux.version')
+        .value('Version', VERSION.version);
+}());


### PR DESCRIPTION
part of #592 

On start up, the application checks the `version` item in LocalStorage. It then parses the current version and the version in the storage, and compares major versions. If they're different, then the `update` function is run.

In this instance, it just removes the cache of windows/indicators, because I thought some functionality would be better than none. (Plus, since everything's downloaded at run time, we can change this in the next release and that newer code would be run.)

This PR also brings the version value used by angular into its own `version-value.js` file, and some very minor `grunt bump` changes.