### PR TITLE
Minichart is self-contained; show error if not enough data

### DIFF
--- a/src/sidebars/favourites/favourite.html
+++ b/src/sidebars/favourites/favourite.html
@@ -10,9 +10,7 @@
             <div class="code">{{stock.code | uppercase}}</div>
         </div>
         <div class="bottom">
-            <div ng-controller="MinichartCtrl as minichartCtrl">
-                <minichart stock="stock" render-chart="minichartCtrl.renderChart(stock)"></minichart>
-            </div>
+            <minichart stock="stock"></minichart>
             <div class="details">
                 <div class="price">{{stock.price | number:2 }}</div>
                 <div class="delta">{{stock.delta < 0 ? '' : '+'}}{{stock.delta | number:2 }}</div>

--- a/src/sidebars/favourites/minichart/minichart-controller.js
+++ b/src/sidebars/favourites/minichart/minichart-controller.js
@@ -3,6 +3,7 @@
 
     class MinichartCtrl {
         constructor(quandlService, $timeout) {
+            this.showMinichart = true;
             this.quandlService = quandlService;
             this.$timeout = $timeout;
         }
@@ -16,6 +17,12 @@
                         var width = extent.width,
                             height = extent.height;
                         var data = result.data;
+
+                        if (data.length < 2) {
+                            this.showMinichart = false;
+                            return;
+                        }
+
                         data = data.map((d) => {
                             var date = moment(d.date);
                             d.date = date.toDate();

--- a/src/sidebars/favourites/minichart/minichart-directive.js
+++ b/src/sidebars/favourites/minichart/minichart-directive.js
@@ -7,9 +7,10 @@
                 restrict: 'E',
                 templateUrl: 'sidebars/favourites/minichart/minichart.html',
                 scope: {
-                    renderChart: '&',
                     stock: '='
-                }
+                },
+                controller: 'MinichartCtrl',
+                controllerAs: 'minichartCtrl'
             };
         }]);
 }());

--- a/src/sidebars/favourites/minichart/minichart.html
+++ b/src/sidebars/favourites/minichart/minichart.html
@@ -1,4 +1,4 @@
-﻿<svg class="minichart" id="{{stock.code}}chart" ng-init="renderChart(stock)">
+﻿<svg class="minichart" id="{{stock.code}}chart" ng-init="minichartCtrl.renderChart(stock)" ng-if="minichartCtrl.showMinichart">
     <defs>
         <linearGradient id="{{stock.code}}-minichart-gradient" x1="0" x2="0" y1="0" y2="1">
             <stop offset="0%" class="minichart-gradient top" />
@@ -6,3 +6,6 @@
         </linearGradient>
     </defs>
 </svg>
+<div class="minichart minichart-error" ng-if="!minichartCtrl.showMinichart">
+    Not enough data to show minichart
+</div>

--- a/src/sidebars/favourites/minichart/minichart.less
+++ b/src/sidebars/favourites/minichart/minichart.less
@@ -36,3 +36,10 @@
     stop-opacity: 0;
   }
 }
+
+.minichart-error {
+    padding: 0px 3px;
+    text-align: center;
+    .font(12px, @font-thin);
+    color: white;
+}


### PR DESCRIPTION
Closes #632 
There was only one bit of history for that stock, so it threw an error in that instance.

I've also made the minichart more self-contained, as it felt weird to have `ng-controller` outside of the `minichart` node. 