### PR TITLE
Fix crash when trying to open the same closed window twice

### DIFF
--- a/src/window-service.js
+++ b/src/window-service.js
@@ -265,12 +265,14 @@
                     showFunction();
                 }
 
-                this.storeService.open(newWindow.name).openWindow();
                 this.snapToScreenBounds(newWindow);
             };
 
             var mainWindow;
             if (name) {
+                // Notify the store service that the window has opened.
+                this.storeService.open(name).openWindow();
+
                 mainWindow = new fin.desktop.Window(
                     isCompact ?
                         this.configService.getCompactConfig(name) :


### PR DESCRIPTION
Move openWindow command to before closed window recreated to make cache consistent; closing #650.

I removed the statement on line `268` as it was doing the same thing, just later on. (If the name exists, then it's marked as opened beforehand -- which I would class as better caching consistency; if the name doesn't, it's already marked as open in the default config)