### PR TITLE
Fix blurred tearouts breaking the window; closes #538

### DIFF
--- a/src/sidebars/favourites/tearout-directive.js
+++ b/src/sidebars/favourites/tearout-directive.js
@@ -87,6 +87,8 @@
                             clearIncomingTearoutWindow();
                             appendToOpenfinWindow(tearElement, tearoutWindow);
                             displayTearoutWindow();
+
+                            tearoutWindow.addEventListener('blurred', onBlur);
                         }
 
                         function handleMouseMove(e) {
@@ -101,6 +103,7 @@
                                 return false;
                             }
                             $rootScope.$broadcast('tearoutEnd');
+                            tearoutWindow.removeEventListener('blurred', onBlur);
 
                             if (currentlyDragging) {
                                 currentlyDragging = false;
@@ -172,6 +175,16 @@
                             }
                         }
 
+                        function onBlur() {
+                            if (currentlyDragging) {
+                                $rootScope.$broadcast('tearoutEnd');
+                                returnFromTearout();
+                                currentlyDragging = false;
+                                dragService.destroy();
+                                tearoutWindow.removeEventListener('blurred', onBlur);
+                            }
+                        }
+
                         tearoutWindow.addEventListener('bounds-changing', boundsChangingEvent);
 
                         dragElement.addEventListener('mousedown', handleMouseDown);
@@ -181,6 +194,7 @@
                         function dispose() {
                             hoverService.remove(scope.stock.code);
                             tearoutWindow.removeEventListener('bounds-changing', boundsChangingEvent);
+                            tearoutWindow.removeEventListener('blurred', onBlur);
                             dragElement.removeEventListener('mousedown', handleMouseDown);
                             document.removeEventListener('mousemove', handleMouseMove);
                             document.removeEventListener('mouseup', handleMouseUp);


### PR DESCRIPTION
A few notes:

* This is triggered on any blur event on the tearout window -- as a result of alt-tab, start keyboard button, right click. Maybe the `Escape` key should also trigger it?
* The event for `blur` is added/removed after the window is shown; it stops situations where you tearout, return and try to tearout and it instantly returns (probably due to hiding/showing the window).
* In this case, tearing out 'cancels' the tearout, so it doesn't tear between windows or create a new window.