### PR TITLE
Search updates

### DIFF
--- a/src/services/quandl-service.js
+++ b/src/services/quandl-service.js
@@ -20,10 +20,9 @@
     }
 
     function processDataset(dataset, query) {
-        var code = dataset.dataset_code;
         return {
             name: dataset.name,
-            code: code,
+            code: dataset.dataset_code,
             favourite: false,
             query: query
         };

--- a/src/services/quandl-service.js
+++ b/src/services/quandl-service.js
@@ -19,16 +19,14 @@
         return moment().subtract(28, 'days');
     }
 
-    function processDataset(dataset, query, cb) {
+    function processDataset(dataset, query) {
         var code = dataset.dataset_code;
-        var stock = {
+        return {
             name: dataset.name,
             code: code,
             favourite: false,
             query: query
         };
-
-        cb(stock);
     }
 
     function isValidResponse(json) {
@@ -87,11 +85,13 @@
 
         search(query, cb, noResultsCb, errorCb, usefallback = false) {
             this.stockSearch(usefallback).get({ query: query }, (result) => {
-                result.datasets.map((dataset) => {
-                    processDataset(dataset, query, cb);
+                var processedDataset = result.datasets.map((dataset) => {
+                    return processDataset(dataset, query);
                 });
 
-                if (result.datasets.length === 0) {
+                if (processedDataset.length > 0) {
+                    cb(processedDataset);
+                } else {
                     noResultsCb();
                 }
             }, (result) => {
@@ -109,7 +109,7 @@
 
         getMeta(stockCode, cb) {
             this.stockMetadata().get({ 'stock_code': stockCode }, (result) => {
-                processDataset(result.dataset, stockCode, cb);
+                cb(processDataset(result.dataset, stockCode));
             });
         }
 

--- a/src/sidebars/search/search-controller.js
+++ b/src/sidebars/search/search-controller.js
@@ -180,7 +180,8 @@
                             this.stocks[index].favourite = data.favourite;
                         }
                     // The stock doesn't exist, push it on if it's a favourite.
-                    } else if (data.favourite) {
+                    // if there's no search results.
+                    } else if (data.favourite && !this.query) {
                         this.stocks.push(data);
                     }
                 });

--- a/src/sidebars/search/search-controller.js
+++ b/src/sidebars/search/search-controller.js
@@ -172,20 +172,33 @@
                     }
                     var index = this.stocks.map((stock) => { return stock.code; }).indexOf(data.code);
                     if (index > -1) {
-                        if (!this.query) {
-                            // There are no search results, so remove the favourite.
-                            this.stocks.splice(index, 1);
-                        } else {
-                            // Update the stock's favourite
-                            this.stocks[index].favourite = data.favourite;
-                        }
-                    // The stock doesn't exist, push it on if it's a favourite.
-                    // if there's no search results.
+                        this.updateFavouriteStates();
                     } else if (data.favourite && !this.query) {
                         this.stocks.push(data);
                     }
                 });
             });
+        }
+
+        /*
+        * Updates the favourite states depending on whether or not they're in
+        * the window's store (this is the best way to ensure that they are
+        * favourites, as the updateFavourites event is broadcast after the store
+        * has been updated).
+        */
+        updateFavouriteStates() {
+            if (!this.store) {
+                this.store = window.storeService.open(window.name);
+            }
+
+            var favs = this.store.get();
+            if (this.query) {
+                this.stocks.forEach((stock) => {
+                    stock.favourite = favs.indexOf(stock.code) > -1;
+                });
+            } else {
+                this.stocks = this.stocks.filter((stock) => favs.indexOf(stock.code) > -1);
+            }
         }
 
         darkenClass(stock) {

--- a/src/sidebars/search/search-controller.js
+++ b/src/sidebars/search/search-controller.js
@@ -122,7 +122,10 @@
                             this.stocks.push(stock);
                         }
                     },
-                    () => {this.noResults = true;},
+                    () => {
+                        this.noResults = true;
+                        this.isLoading = false;
+                    },
                     (error) => {
                         this.isLoading = false;
                         this._addError({

--- a/src/sidebars/search/search-controller.js
+++ b/src/sidebars/search/search-controller.js
@@ -201,7 +201,7 @@
                     var index = this.stocks.map((stock) => { return stock.code; }).indexOf(data.code);
                     if (index > -1) {
                         // If the stock in question doesn't exist on the list, check
-                        // the favourites and upadte accordingly
+                        // the favourites and update accordingly
                         this.updateFavouriteStates();
                     } else if (data.favourite && !this.query) {
                         // If there's no query, and the new stock is a favourite,

--- a/src/sidebars/search/search-controller.js
+++ b/src/sidebars/search/search-controller.js
@@ -19,15 +19,22 @@
             this._watch();
         }
 
-        hasStore() {
+        getStore() {
             if (!window.storeService) {
-                return false;
+                return null;
             }
 
             if (!this.store) {
                 this.store = window.storeService.open(window.name);
             }
-            return true;
+            return this.store;
+        }
+
+        getFavourites() {
+            if (this.getStore()) {
+                return this.store.get();
+            }
+            return null;
         }
 
         selection() {
@@ -35,7 +42,7 @@
         }
 
         select(stock) {
-            if (this.hasStore() && !this.store.isCompact()) {
+            if (this.getStore() && !this.store.isCompact()) {
                 this.selectionService.select(stock);
             }
         }
@@ -86,7 +93,7 @@
             this.noResults = false;
 
             this.currentWindowService.ready(() => {
-                if (this.hasStore()) {
+                if (this.getStore()) {
                     if (this.query) {
                         this.isLoading = true;
                         this.errors = [];
@@ -119,8 +126,7 @@
                                 }
 
                                 var stockAdded = false;
-                                var favourites = this.store.get();
-                                favourites.forEach((favourite) => {
+                                this.getFavourites().forEach((favourite) => {
                                     if (stock.code === favourite) {
                                         stock.favourite = true;
                                         this.stocks.unshift(stock);
@@ -152,8 +158,9 @@
         }
 
         displayFavourites() {
-            if (this.hasStore()) {
-                this.store.get().map((favourite) => {
+            var favourites = this.getFavourites();
+            if (favourites) {
+                favourites.map((favourite) => {
                     this.quandlService.getMeta(favourite, (stock) => {
                         stock.favourite = true;
                         this.stocks.push(stock);
@@ -212,17 +219,17 @@
         * has been updated).
         */
         updateFavouriteStates() {
-            if (this.hasStore()) {
-                var favs = this.store.get();
+            var favourites = this.getFavourites();
+            if (this.getFavourites()) {
                 if (this.query) {
                     // If there's a query, check to see if each stock in the query
                     // is a favourite or not.
                     this.stocks.forEach((stock) => {
-                        stock.favourite = favs.indexOf(stock.code) > -1;
+                        stock.favourite = favourites.indexOf(stock.code) > -1;
                     });
                 } else {
                     // If there's no query, remove any non-favourites.
-                    this.stocks = this.stocks.filter((stock) => favs.indexOf(stock.code) > -1);
+                    this.stocks = this.stocks.filter((stock) => favourites.indexOf(stock.code) > -1);
                 }
             }
         }

--- a/src/sidebars/search/search-controller.js
+++ b/src/sidebars/search/search-controller.js
@@ -92,17 +92,17 @@
                         var length = favourites.length;
                         this.isLoading = true;
                         this.errors = [];
-                        this.quandlService.search(this.query, (stock) => {
+                        this.quandlService.search(this.query, (stocks) => {
                             this.isLoading = false;
-                            var i;
 
                             // removing stocks found with old query
-                            this.stocks = this.stocks.filter((result, j) => {
+                            this.stocks = this.stocks.filter((result) => {
                                 return result.query === this.query;
                             });
 
-                            // not adding old stocks
-                            if (stock.query !== this.query) {
+                            // Only show the favourites if the query is empty
+                            if (this.query.trim() === '') {
+                                this.displayFavourites();
                                 return;
                             }
 
@@ -114,18 +114,25 @@
                             // Here we re-set the flag to keep it up-to-date.
                             this.noResults = false;
 
-                            var stockAdded = false;
-                            for (i = 0; i < length; i++) {
-                                if (stock.code === favourites[i]) {
-                                    stock.favourite = true;
-                                    this.stocks.unshift(stock);
-                                    stockAdded = true;
+                            stocks.forEach((stock) => {
+                                // not adding old stocks
+                                if (stock.query !== this.query) {
+                                    return;
                                 }
-                            }
 
-                            if (!stockAdded) {
-                                this.stocks.push(stock);
-                            }
+                                var stockAdded = false;
+                                for (var i = 0; i < length; i++) {
+                                    if (stock.code === favourites[i]) {
+                                        stock.favourite = true;
+                                        this.stocks.unshift(stock);
+                                        stockAdded = true;
+                                    }
+                                }
+
+                                if (!stockAdded) {
+                                    this.stocks.push(stock);
+                                }
+                            });
                         },
                         () => {
                             this.noResults = true;
@@ -139,15 +146,21 @@
                             });
                         });
                     } else {
-                        favourites.map((favourite) => {
-                            this.quandlService.getMeta(favourite, (stock) => {
-                                stock.favourite = true;
-                                this.stocks.push(stock);
-                            });
-                        });
+                        this.displayFavourites();
                     }
                 }
             });
+        }
+
+        displayFavourites() {
+            if (this.hasStore()) {
+                this.store.get().map((favourite) => {
+                    this.quandlService.getMeta(favourite, (stock) => {
+                        stock.favourite = true;
+                        this.stocks.push(stock);
+                    });
+                });
+            }
         }
 
         _addError(newError) {

--- a/src/sidebars/search/search-controller.js
+++ b/src/sidebars/search/search-controller.js
@@ -193,8 +193,12 @@
                     }
                     var index = this.stocks.map((stock) => { return stock.code; }).indexOf(data.code);
                     if (index > -1) {
+                        // If the stock in question doesn't exist on the list, check
+                        // the favourites and upadte accordingly
                         this.updateFavouriteStates();
                     } else if (data.favourite && !this.query) {
+                        // If there's no query, and the new stock is a favourite,
+                        // add it to the list.
                         this.stocks.push(data);
                     }
                 });
@@ -211,10 +215,13 @@
             if (this.hasStore()) {
                 var favs = this.store.get();
                 if (this.query) {
+                    // If there's a query, check to see if each stock in the query
+                    // is a favourite or not.
                     this.stocks.forEach((stock) => {
                         stock.favourite = favs.indexOf(stock.code) > -1;
                     });
                 } else {
+                    // If there's no query, remove any non-favourites.
                     this.stocks = this.stocks.filter((stock) => favs.indexOf(stock.code) > -1);
                 }
             }

--- a/src/sidebars/search/search-controller.js
+++ b/src/sidebars/search/search-controller.js
@@ -87,9 +87,7 @@
 
             this.currentWindowService.ready(() => {
                 if (this.hasStore()) {
-                    var favourites = this.store.get();
                     if (this.query) {
-                        var length = favourites.length;
                         this.isLoading = true;
                         this.errors = [];
                         this.quandlService.search(this.query, (stocks) => {
@@ -121,13 +119,14 @@
                                 }
 
                                 var stockAdded = false;
-                                for (var i = 0; i < length; i++) {
-                                    if (stock.code === favourites[i]) {
+                                var favourites = this.store.get();
+                                favourites.forEach((favourite) => {
+                                    if (stock.code === favourite) {
                                         stock.favourite = true;
                                         this.stocks.unshift(stock);
                                         stockAdded = true;
                                     }
-                                }
+                                });
 
                                 if (!stockAdded) {
                                     this.stocks.push(stock);


### PR DESCRIPTION
A fairly hefty refactor of the search component:

Major changes:
* The search part of the Quandl service now callbacks with the array of all stocks, as opposed to calling back for each stock
* Refactored the store service checking to a function `hasStore`, which returns `true` if the store exists. If it doesn't, it checks to see if the store service is available to be bound, and binds it. Otherwise, it returns `false`. Removes a bit of code duplication.
* The favourite updates are now comprehensively applied using more up-to-date data from the store service
* Closes #639 
* Closes #641 
* Closes #663 