### PR TITLE
Hotfix 10.0.1 devmerge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # StockFlux
 
-StockFlux is a desktop application developed by [Scott Logic](http://www.scottlogic.com/) that uses the OpenFin HTML5 container. 
+StockFlux is a desktop application developed by [Scott Logic](http://www.scottlogic.com/) that uses the OpenFin HTML5 container.
 
 ![Image of StockFlux](https://cloud.githubusercontent.com/assets/1098110/13568013/a02e0fc8-e456-11e5-9543-4642a54c3e2a.png)
 
@@ -13,7 +13,7 @@ Here are a few things to try:
 
 ## Installing
 
-In order to install the application, download [StockFlux installer zipfile](http://scottlogic.github.io/StockFlux/master/StockFlux-master.zip), unzip and run the executable. If you haven't already installed an OpenFin application, this will install the required runtime. It'll also add shortcuts to StockFlux to your desktop and start menu.
+In order to install the application, download [StockFlux installer zipfile](https://dl.openfin.co/services/download?fileName=StockFlux-master&config=http://scottlogic.github.io/StockFlux/master/app.json), unzip and run the executable. If you haven't already installed an OpenFin application, this will install the required runtime. It'll also add shortcuts to StockFlux to your desktop and start menu.
 
 This is an 'evergreen' application, each time it launches the application code is downloaded (from GitHub pages), ensuring that it is always up-to-date.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitflux-openfin",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "type": "develop",
   "scripts": {
     "test": "grunt ci",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitflux-openfin",
-  "version": "10.0.1",
+  "version": "10.1.0-rc.0",
   "type": "develop",
   "scripts": {
     "test": "grunt ci",

--- a/src/app.json
+++ b/src/app.json
@@ -9,8 +9,8 @@
         "defaultHeight": 0,
         "frame": false,
         "showTaskbarIcon": false,
-        "url": "http://scottlogic.github.io/StockFlux/develop/parent.html",
-        "applicationIcon": "http://scottlogic.github.io/StockFlux/develop/favicon.ico"
+        "url": "http://scottlogic.github.io/StockFlux/master/parent.html",
+        "applicationIcon": "http://scottlogic.github.io/StockFlux/master/favicon.ico"
     },
     "runtime": {
         "arguments": "--enable-aggressive-domstorage-flushing",
@@ -19,7 +19,7 @@
     "shortcut": {
         "company": "ScottLogic",
         "description": "Hosts BitFlux as an OpenFin application.",
-        "icon": "http://scottlogic.github.io/StockFlux/develop/favicon.ico",
+        "icon": "http://scottlogic.github.io/StockFlux/master/favicon.ico",
         "name": "StockFlux"
     }
 }

--- a/src/version-value.js
+++ b/src/version-value.js
@@ -1,7 +1,7 @@
 (function() {
     'use strict';
 
-    const VERSION = { version: '10.0.1' };
+    const VERSION = { version: '10.1.0-rc.0' };
 
     angular.module('stockflux.version')
         .value('Version', VERSION.version);

--- a/src/version-value.js
+++ b/src/version-value.js
@@ -1,7 +1,7 @@
 (function() {
     'use strict';
 
-    const VERSION = { version: '10.0.0' };
+    const VERSION = { version: '10.0.1' };
 
     angular.module('stockflux.version')
         .value('Version', VERSION.version);


### PR DESCRIPTION
Merge the 10.0.1 patch into dev.

Bump dev version to pre minor to prevent it overwriting master 10.0.1 gh-pages version. See #713 