### PR TITLE
Tearout card reordering is done by intersection area

### DIFF
--- a/src/sidebars/favourites/geometry-service.js
+++ b/src/sidebars/favourites/geometry-service.js
@@ -45,6 +45,18 @@
                 otherOrigin.x < this.corner().x &&
                 otherOrigin.y < this.corner().y;
         }
+
+        areaOfIntersection(otherRectangle) {
+            if (this.intersects(otherRectangle)) {
+                var left = Math.max(this.left(), otherRectangle.left());
+                var right = Math.min(this.right(), otherRectangle.right());
+                var top = Math.max(this.top(), otherRectangle.top());
+                var bottom = Math.min(this.bottom(), otherRectangle.bottom());
+                return (right - left) * (bottom - top);
+            } else {
+                return 0;
+            }
+        }
     }
 
     // Helper function to retrieve the height, width, top, and left from a window object
@@ -69,20 +81,27 @@
         };
     }
 
-    function intersectHelper(bounds1, bounds2) {
-        var rectangle1 = new Rectangle(bounds1),
-            rectangle2 = new Rectangle(bounds2);
-
-        return rectangle1.intersects(rectangle2);
+    function rectangles(bounds1, bounds2) {
+        return [new Rectangle(bounds1), new Rectangle(bounds2)];
     }
 
     class GeometryService {
         elementIntersect(openFinWindow, _window, element) {
             var nativeWindow = openFinWindow.getNativeWindow();
-
-            return intersectHelper(
+            var rects = rectangles(
                 getWindowPosition(nativeWindow),
                 elementScreenPosition(getWindowPosition(_window), element));
+
+            return rects[0].intersects(rects[1]);
+        }
+
+        elementIntersectArea(openFinWindow, _window, element) {
+            var nativeWindow = openFinWindow.getNativeWindow();
+            var rects = rectangles(
+                getWindowPosition(nativeWindow),
+                elementScreenPosition(getWindowPosition(_window), element));
+
+            return rects[0].areaOfIntersection(rects[1]);
         }
     }
 

--- a/src/sidebars/favourites/tearout-directive.js
+++ b/src/sidebars/favourites/tearout-directive.js
@@ -22,7 +22,7 @@
 
                         var myDropTarget = tearElement.parentNode,
                             parent = myDropTarget.parentNode,
-                            myHoverArea = parent.getElementsByClassName('hover-area')[0],
+                            myHoverArea = parent.getElementsByClassName('drop-target')[0],
                             mouseOffset = { x: 0, y: 0 },
                             elementOffset = { x: 0, y: 0 },
                             currentlyDragging = false,
@@ -182,7 +182,6 @@
                                         }
 
                                         // Remove drop-target from original instance
-                                        parent.removeChild(myHoverArea);
                                         parent.removeChild(myDropTarget);
                                         dispose();
 
@@ -195,19 +194,25 @@
 
                         function reorderFavourites() {
                             var hoverTargets = hoverService.get();
+                            var largestIntersectionArea = -1;
+                            var largestIntersector = hoverTargets[0];
 
                             for (var i = 0, max = hoverTargets.length; i < max; i++) {
-                                var overDropTarget = geometryService.elementIntersect(
+                                var areaOfIntersection = geometryService.elementIntersectArea(
                                     tearoutWindow, window, hoverTargets[i].hoverArea);
 
-                                if (overDropTarget) {
-                                    if (!store) {
-                                        store = window.storeService.open(window.name);
-                                    }
-
-                                    store.reorder(scope.stock.code, hoverTargets[i].code);
-                                    break;
+                                if (areaOfIntersection > largestIntersectionArea) {
+                                    largestIntersectionArea = areaOfIntersection;
+                                    largestIntersector = hoverTargets[i];
                                 }
+                            }
+
+                            if (largestIntersectionArea > 0 && largestIntersector) {
+                                if (!store) {
+                                    store = window.storeService.open(window.name);
+                                }
+
+                                store.reorder(scope.stock.code, largestIntersector.code);
                             }
                         }
 


### PR DESCRIPTION
Closes #636 -- intersection's done by intersection area with the card, as opposed to using the divider for intersection checks.