### PR TITLE
Resizability on compact-created windows

### DIFF
--- a/src/config-service.js
+++ b/src/config-service.js
@@ -65,22 +65,6 @@
             });
         }
 
-        getCompactConfig(name) {
-            return this._getConfig(name, {
-                showTaskbarIcon: true,
-                saveWindowState: true,
-                url: 'index.html',
-                resizable: false,
-                maximizable: false,
-                minWidth: COMPACT_WINDOW_DIMENSIONS[0],
-                minHeight: COMPACT_WINDOW_DIMENSIONS[1],
-                maxWidth: COMPACT_WINDOW_DIMENSIONS[0],
-                maxHeight: COMPACT_WINDOW_DIMENSIONS[1],
-                defaultWidth: COMPACT_WINDOW_DIMENSIONS[0],
-                defaultHeight: COMPACT_WINDOW_DIMENSIONS[1]
-            });
-        }
-
         getTearoutConfig(name) {
             return this._getConfig(name, {
                 maximizable: false,

--- a/src/config-service.js
+++ b/src/config-service.js
@@ -24,12 +24,33 @@
             return 'window' + Math.floor(Math.random() * 1000) + Math.ceil(Math.random() * 999);
         }
 
-        getWindowConfig(name) {
-            return {
+        _getConfig(name, overrides) {
+            var sharedConfig = {
                 name: name || this.createName(),
                 contextMenu: allowContextMenu,
                 autoShow: false,
                 frame: false,
+                shadow: true,
+                resizeRegion: {
+                    size: 7,
+                    topLeftCorner: 14,
+                    topRightCorner: 14,
+                    bottomRightCorner: 14,
+                    bottomLeftCorner: 14
+                }
+            };
+
+            Object.keys(sharedConfig).forEach((key) => {
+                if (overrides[key] === undefined) {
+                    overrides[key] = sharedConfig[key];
+                }
+            });
+
+            return overrides;
+        }
+
+        getWindowConfig(name) {
+            return this._getConfig(name, {
                 showTaskbarIcon: true,
                 saveWindowState: true,
                 url: 'index.html',
@@ -40,24 +61,12 @@
                 maxWidth: RESIZE_NO_LIMIT,
                 maxHeight: RESIZE_NO_LIMIT,
                 defaultWidth: DEFAULT_WINDOW_DIMENSIONS[0],
-                defaultHeight: DEFAULT_WINDOW_DIMENSIONS[1],
-                shadow: true,
-                resizeRegion: {
-                    size: 7,
-                    topLeftCorner: 14,
-                    topRightCorner: 14,
-                    bottomRightCorner: 14,
-                    bottomLeftCorner: 14
-                }
-            };
+                defaultHeight: DEFAULT_WINDOW_DIMENSIONS[1]
+            });
         }
 
         getCompactConfig(name) {
-            return {
-                name: name || this.createName(),
-                contextMenu: allowContextMenu,
-                autoShow: false,
-                frame: false,
+            return this._getConfig(name, {
                 showTaskbarIcon: true,
                 saveWindowState: true,
                 url: 'index.html',
@@ -68,26 +77,20 @@
                 maxWidth: COMPACT_WINDOW_DIMENSIONS[0],
                 maxHeight: COMPACT_WINDOW_DIMENSIONS[1],
                 defaultWidth: COMPACT_WINDOW_DIMENSIONS[0],
-                defaultHeight: COMPACT_WINDOW_DIMENSIONS[1],
-                shadow: true
-            };
+                defaultHeight: COMPACT_WINDOW_DIMENSIONS[1]
+            });
         }
 
         getTearoutConfig(name) {
-            return {
-                name: name || this.createName(),
-                contextMenu: allowContextMenu,
-                autoShow: false,
-                frame: false,
+            return this._getConfig(name, {
                 maximizable: false,
                 resizable: false,
                 showTaskbarIcon: false,
                 saveWindowState: false,
                 maxWidth: TEAROUT_CARD_DIMENSIONS[0],
                 maxHeight: TEAROUT_CARD_DIMENSIONS[1],
-                url: 'tearout.html',
-                shadow: true
-            };
+                url: 'tearout.html'
+            });
         }
 
         getTearoutCardDimensions() {

--- a/src/toolbar/toolbar-controller.js
+++ b/src/toolbar/toolbar-controller.js
@@ -67,6 +67,7 @@
                 compactWindowDimensions = this.configService.getCompactWindowDimensions();
             if (window.outerWidth !== compactWindowDimensions[0]) {
                 this.oldSize = [window.outerWidth, window.outerHeight];
+                this.wasMaximised = this.maximised;
             }
 
             if (window.windowService) {
@@ -77,7 +78,7 @@
                 reportAction('Window change', 'Compact');
                 this.window.resizeTo(compactWindowDimensions[0], compactWindowDimensions[1], 'top-right');
             }
-            else if (this.maximised) {
+            else if (this.wasMaximised) {
                 reportAction('Window change', 'Maximised');
                 this.window.maximize();
             }

--- a/src/window-service.js
+++ b/src/window-service.js
@@ -274,10 +274,12 @@
                 this.storeService.open(name).openWindow();
 
                 mainWindow = new fin.desktop.Window(
-                    isCompact ?
-                        this.configService.getCompactConfig(name) :
-                        this.configService.getWindowConfig(name),
+                    this.configService.getWindowConfig(name),
                     () => {
+                        if (isCompact) {
+                            this.updateOptions(mainWindow, true);
+                            mainWindow.resizeTo(230, 500, 'top-left');
+                        }
                         windowCreatedCb(mainWindow);
                     }
                 );

--- a/src/window-service.js
+++ b/src/window-service.js
@@ -277,8 +277,9 @@
                     this.configService.getWindowConfig(name),
                     () => {
                         if (isCompact) {
+                            var compactSize = this.configService.getCompactWindowDimensions();
                             this.updateOptions(mainWindow, true);
-                            mainWindow.resizeTo(230, 500, 'top-left');
+                            mainWindow.resizeTo(compactSize[0], compactSize[1], 'top-left');
                         }
                         windowCreatedCb(mainWindow);
                     }


### PR DESCRIPTION
Closes #647 

* Adds a 'shared' config, which adds the shared values to main window/tearout card configs (less to maintain)
* Removes the compact window config in favour of checking to see if the window is indeed compact when it's about to be displayed, and then updating the compact flags. The positioning works between app runs because of `top-left`.
* Commit 3 closes #633 by adding a flag for `wasMaximised`, as the `restored` event fired when switching between maximised and compact view