### PR TITLE
Fix mousedown on favourite removal confirm button triggering hide modal

### DIFF
--- a/src/sidebars/star/star.html
+++ b/src/sidebars/star/star.html
@@ -2,7 +2,8 @@
      ng-mouseenter="starCtrl.mouseEnter()" ng-mouseleave="starCtrl.mouseLeave()" title="{{starCtrl.tooltip()}}" draggable="false" />
 <div class="confirmation-backdrop" ng-if="starCtrl.confirmationShow" ng-mousedown="starCtrl.hideModal(); $event.stopPropagation();">
   <div class="bubble-head" ng-style="{top:starCtrl.modalBubbleTop()+'px'}"></div>
-  <div class="confirmation-modal" ng-class="{flipped: starCtrl.modalFlip()}"  ng-click="$event.stopPropagation();" ng-style="{top:starCtrl.modalTop()+'px'}">
+  <div class="confirmation-modal" ng-class="{flipped: starCtrl.modalFlip()}" ng-click="$event.stopPropagation();"
+    ng-mousedown="$event.stopPropagation();" ng-style="{top:starCtrl.modalTop()+'px'}">
     <div class=confirmation-content>
       <div class="message">
         <span>Are you sure you wish to remove this stock from your favourites?</span>

--- a/src/sidebars/star/star.html
+++ b/src/sidebars/star/star.html
@@ -1,6 +1,7 @@
 ﻿<img class="star" ng-src="assets/png/{{starCtrl.favouriteUrl()}}.png" ng-click="starCtrl.click($event); $event.stopPropagation();"
      ng-mouseenter="starCtrl.mouseEnter()" ng-mouseleave="starCtrl.mouseLeave()" title="{{starCtrl.tooltip()}}" draggable="false" />
-<div class="confirmation-backdrop" ng-if="starCtrl.confirmationShow" ng-mousedown="starCtrl.hideModal(); $event.stopPropagation();">
+<div class="confirmation-backdrop" ng-if="starCtrl.confirmationShow" ng-mousedown="starCtrl.hideModal(); $event.stopPropagation();"
+    ng-dblclick="$event.stopPropagation()">
   <div class="bubble-head" ng-style="{top:starCtrl.modalBubbleTop()+'px'}"></div>
   <div class="confirmation-modal" ng-class="{flipped: starCtrl.modalFlip()}" ng-click="$event.stopPropagation();"
     ng-mousedown="$event.stopPropagation();" ng-style="{top:starCtrl.modalTop()+'px'}">


### PR DESCRIPTION
Closes #731 

Adds a `mousedown` event to the confirmation modal to stop the propagation. I'd tried doing some pointer event CSS magic to hopefully make this a bit nicer to approach, but it didn't work, so this was the next best alternative