### PR TITLE
Restore transition for compact favourites scrollbar

### DIFF
--- a/src/sidebars/favourites/favourite-compact.less
+++ b/src/sidebars/favourites/favourite-compact.less
@@ -10,8 +10,4 @@
       }
     }
   }
-
-  .favourite .top {
-    transition: none;
-  }
 }


### PR DESCRIPTION
Closes #703 

Not sure why it was disabled before for compact?