### PR TITLE
Tearout single stocks WIP

### DIFF
--- a/src/config-service.js
+++ b/src/config-service.js
@@ -30,7 +30,7 @@
                 contextMenu: allowContextMenu,
                 autoShow: false,
                 frame: false,
-                shadow: true,
+                shadow: false,
                 resizeRegion: {
                     size: 7,
                     topLeftCorner: 14,

--- a/src/sidebars/favourites/favourite-controller.js
+++ b/src/sidebars/favourites/favourite-controller.js
@@ -134,9 +134,9 @@
 
                             // Repeat the check as in the mean time a stock for this favourite could have been added.
                             if (this.stocks.map((stock1) => { return stock1.code; }).indexOf(favourite) === -1) {
-                                var data = stock && stock.data && stock.data[0],
-                                    delta = data.close - data.open;
+                                var data = stock && stock.data && stock.data[0];
                                 if (data) {
+                                    var delta = data.close - data.open;
                                     this.stocks.push({
                                         favourite: true,
                                         name: stock.name,

--- a/src/sidebars/favourites/favourites.less
+++ b/src/sidebars/favourites/favourites.less
@@ -49,10 +49,6 @@
   .size(@width: @expanded-width, @height: @favourite-height);
   cursor: pointer;
 
-  .single {
-    cursor: default;
-  }
-
   .top {
     padding-left: @top-padding-left;
     .transition();

--- a/src/sidebars/favourites/tearout-directive.js
+++ b/src/sidebars/favourites/tearout-directive.js
@@ -206,6 +206,7 @@
                             if (mouseDown && dragTimeout) {
                                 if (Math.abs(e.pageX + mouseOffset.x) > 50 || Math.abs(e.pageY + mouseOffset.y) > 50) {
                                     $timeout.cancel(dragTimeout);
+                                    dragTimeout = null;
                                     tearout(e);
                                 }
                             }

--- a/src/sidebars/favourites/tearout-directive.js
+++ b/src/sidebars/favourites/tearout-directive.js
@@ -101,10 +101,8 @@
 
                             tearoutWindow.addEventListener('blurred', onBlur);
 
-                            if (tearElement.classList.contains('single')) {
-                                // There is only one favourite card; flag the window for closing
-                                emptyWindow = true;
-                            }
+                            // If there's is only one favourite card; flag the window for closing
+                            emptyWindow = tearElement.classList.contains('single');
 
                             currentlyDragging = true;
                         }
@@ -240,6 +238,10 @@
                                 currentlyDragging = false;
                                 if (dragService.overThisInstance(TEAR_IN_SELECTOR)) {
                                     returnFromTearout();
+                                    if (emptyWindow) {
+                                        stopTimer();
+                                        undim();
+                                    }
                                 } else {
                                     if (!store) {
                                         store = window.storeService.open(window.name);
@@ -257,6 +259,7 @@
                                                 currentWindowService.getCurrentWindow().close();
                                                 return;
                                             }
+                                            tidy();
                                         } else if (emptyWindow) {
                                             returnFromTearout();
                                             stopTimer();
@@ -277,9 +280,9 @@
                                                 store.remove(scope.stock);
                                                 newStore.toggleCompact(compact);
                                             });
+                                            tidy();
                                         }
 
-                                        tidy();
                                     });
                                 }
                             }


### PR DESCRIPTION
This PR introduces tearing out the final stock in a window. As per #726 the window will fade after an amount of time after the card has been torn and left the tearout area, and will fade back in if the card stops moving.

Issues/bugs:

- [ ] The window shadow is still present after the window has faded
- [ ] The window sometimes fades in and out twice, instead of once
- [ ] Quickly tearing out a card and letting go of the mouse will result in a window with the favourite missing (but it's there in search and the window behaves as if it has one stock!). This could potentially be resolved by not keeping the old window and instead destroying it and recreating a new window. This feels wasteful but would work. (There would be no fade effect either).