### PR TITLE
Prevent gh-pages version overwrites from dev build. 

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -255,7 +255,7 @@ module.exports = function(grunt) {
     grunt.registerTask('transpile', ['babel', 'less:development']);
 
     grunt.registerTask('build:dev', ['concatenate', 'transpile', 'connect:livereload']);
-    grunt.registerTask('build:release', ['concatenate', 'string-replace', 'transpile', 'uglify', 'connect:livereload']);
+    grunt.registerTask('build:release', ['concatenate', 'string-replace', 'transpile', 'uglify']);
 
     grunt.registerTask('serve', ['build:dev', 'openfin:serve']);
     grunt.registerTask('default', ['serve']);


### PR DESCRIPTION
Updated deploy script to publish to gh pages the following:

| Branch | gh-pages version  |
|--- |---|
|master| master and _version_ |
| dev | dev |
| release-* |  _version_-rc |

_version_ is from package.json

Closes #713 #595 