### PR TITLE
Update Travis to run on Node 4.4.x to reduce build errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - "4.0"
+  - "4.4"
 
 sudo: false
 


### PR DESCRIPTION
Feel free to decline this, if there's a reason not to update :) but this should lead to more reliable builds.

This related to https://github.com/ScottLogic/StockFlux/issues/732#issuecomment-217374493