### PR TITLE
refactor: ensure event handlers are removed when unmounting favourite

### DIFF
--- a/src/child/components/Favourite.js
+++ b/src/child/components/Favourite.js
@@ -12,11 +12,14 @@ class Favourite extends Component {
     constructor(props) {
         super(props);
         this.onIconClick = this.onIconClick.bind(this);
+        this.onDragStart = this.onDragStart.bind(this);
+        this.onDragOver = this.onDragOver.bind(this);
+        this.onDragLeave = this.onDragLeave.bind(this);
+        this.onDragEnd = this.onDragEnd.bind(this);
     }
 
     componentDidMount() {
         const stockCode = this.props.stockCode;
-        this.addDragTarget(stockCode);
         quandlServiceGetStockData(stockCode)
             .then(response => {
                 const data = response.stockData.data[0];
@@ -38,36 +41,29 @@ class Favourite extends Component {
         this.props.bindings.onIconClick(this.props.stockCode);
     }
 
-    addDragTarget(stockCode) {
-        const dragTarget = document.getElementById(`stock_${stockCode}`);
-        dragTarget.addEventListener('dragstart', e => {
+    onDragStart(stockCode) {
+        return e => {
             // TODO: fade out window if it's last stock
-            dragTarget.classList.add('dragging');
+            e.currentTarget.classList.add('dragging');
             e.dataTransfer.setData('text/plain', stockCode);
             e.dataTransfer.setData(stockCode, '');  // used to access propery on dragEnter. check getCodeFromDT
-        }, false);
+        };
+    }
 
-        dragTarget.addEventListener('dragover', e => {
-            e.preventDefault();
-            e.stopPropagation();
-        }, false);
+    onDragOver(e) {
+        e.preventDefault();
+        e.stopPropagation();
+    }
 
-        dragTarget.addEventListener('dragenter', e => this.props.bindings.dnd.onDragEnter(e, stockCode), false);
+    onDragLeave(e) {
+        e.currentTarget.classList.remove('dragOver');
+    }
 
-        dragTarget.addEventListener('dragleave', () => {
-            dragTarget.classList.remove('dragOver');
-        }, false);
-
-        dragTarget.addEventListener('drop', e => this.props.bindings.dnd.onDrop(e, stockCode), false);
-
-        dragTarget.addEventListener('dragend', e => {
-            // If the dropEffect property has the value 'none' on dragend,
-            // then the drag was cancelled
-            dragTarget.classList.remove('dragging');
-            if (e.dataTransfer.dropEffect === 'none') {
-                // TODO: Open window with stock + reposition && fade window if it's the only stock in favourites
-            }
-        }, false);
+    onDragEnd(e) {
+        e.currentTarget.classList.remove('dragging');
+        if (e.dataTransfer.dropEffect === 'none') {
+            // TODO: Open window with stock + reposition && fade window if it's the only stock in favourites
+        }
     }
 
     render() {
@@ -92,6 +88,12 @@ class Favourite extends Component {
               draggable="true"
               className="favouriteWrapper"
               onClick={() => bindings.onClick(stockCode, name)}
+              onDragStart={this.onDragStart(stockCode)}
+              onDragOver={this.onDragOver}
+              onDragEnter={e => bindings.dnd.onDragEnter(e, stockCode)}
+              onDragLeave={this.onDragLeave}
+              onDrop={e => bindings.dnd.onDrop(e, stockCode)}
+              onDragEnd={this.onDragEnd}
               onDoubleClick={() => bindings.onDoubleClick(stockCode, name)}
             >
                 <div className="drop-target">

--- a/src/child/containers/sidebars/favourites/Favourites.js
+++ b/src/child/containers/sidebars/favourites/Favourites.js
@@ -33,10 +33,12 @@ class Favourites extends Component {
         this.onDropOverFavourite = this.onDropOverFavourite.bind(this);
         this.onQuandlResponse = this.onQuandlResponse.bind(this);
         this.onDoubleClick = this.onDoubleClick.bind(this);
+        this.onDrop = this.onDrop.bind(this);
+        this.onDragOver = this.onDragOver.bind(this);
+        this.onDragLeave = this.onDragLeave.bind(this);
     }
 
     componentDidMount() {
-        this.addDropTarget('favDropTarget');
         const scrollPadding = 'scroll-padding';
         const el = this.refs.scrollarea;
         $(this.refs.scrollarea).mCustomScrollbar({
@@ -96,29 +98,23 @@ class Favourites extends Component {
         this.props.bindings.toggleFavourite(stockCode);
     }
 
-    addDropTarget(id) {
-        const dropTarget = document.getElementById(id);
-        this.dropTarget = dropTarget;
-
-        dropTarget.addEventListener('drop', e => {
-            const codes = this.props.favourites.codes;
-            const code = e.dataTransfer.getData('text/plain');
-            this.props.dispatch(insertFavouriteAt(codes.length, code));
-            dropTarget.classList.remove('dragOver');
-        }, false);
-
-        dropTarget.addEventListener('dragover', e => {
-            if (!dropTarget.classList.contains('dragOver')) {
-                dropTarget.classList.add('dragOver');
-            }
-            e.preventDefault();
-        }, false);
-
-        dropTarget.addEventListener('dragleave', () => {
-            dropTarget.classList.remove('dragOver');
-        }, false);
+    onDrop(e) {
+        const codes = this.props.favourites.codes;
+        const code = e.dataTransfer.getData('text/plain');
+        this.props.dispatch(insertFavouriteAt(codes.length, code));
+        e.currentTarget.classList.remove('dragOver');
     }
 
+    onDragOver(e) {
+        if (!e.currentTarget.classList.contains('dragOver')) {
+            e.currentTarget.classList.add('dragOver');
+        }
+        e.preventDefault();
+    }
+
+    onDragLeave(e) {
+        e.currentTarget.classList.remove('dragOver');
+    }
 
     render() {
         const { favourites, hasErrors, isStarting, selection } = this.props;
@@ -134,7 +130,13 @@ class Favourites extends Component {
             onDoubleClick: this.onDoubleClick
         };
         return (
-            <div id="favDropTarget" className="favDropTarget" >
+            <div
+              id="favDropTarget"
+              className="favDropTarget"
+              onDrop={this.onDrop}
+              onDragOver={this.onDragOver}
+              onDragLeave={this.onDragLeave}
+            >
                 <div className="sidetab-top">
                     <img src={favTabImage} className="top-icon" title="Favourites List" draggable="false" />
                 </div>


### PR DESCRIPTION
Fixes https://github.com/ScottLogic/StockFlux/pull/809#discussion_r64578393

This uses react's synthetic events, so now the event handlers are removed automatically when a favourite is unmounted. See [here](https://facebook.github.io/react/docs/interactivity-and-dynamic-uis.html#under-the-hood-autobinding-and-event-delegation).