### PR TITLE
fix: prevent drag on no favourites image

### DIFF
--- a/src/child/assets/styles/style.less
+++ b/src/child/assets/styles/style.less
@@ -108,4 +108,5 @@ body {
     max-height: 500px;
     width: 100%;
     position: relative;
+    -webkit-user-drag: none;
 }


### PR DESCRIPTION
Not sure if we want this, but I find it fairly annoying that the no favourites image can be dragged.