### PR TITLE
fix: set bindings prop on compact view Search container

### DIFF
--- a/src/child/containers/sidebars/Sidebar.js
+++ b/src/child/containers/sidebars/Sidebar.js
@@ -54,7 +54,7 @@ class Sidebar extends Component {
                     <Search bindings={bindings} />
                 </div>
                 <div className={`search compact-search ${sidebar.showSearch ? 'expanded' : 'contracted'}`} onClick={this.focusSearch}>
-                    <Search />
+                    <Search bindings={bindings} />
                 </div>
                 <div className={`favourites ${sidebar.showFavourites ? 'expanded' : 'contracted'}`} onClick={this.focusFav}>
                     <Favourites bindings={bindings} />


### PR DESCRIPTION
bindings is a required property for the Search container