### PR TITLE
fix: fix drag and drop

### DIFF
--- a/src/child/components/SearchResult.js
+++ b/src/child/components/SearchResult.js
@@ -26,7 +26,7 @@ const Stock = ({ isFavourite, stock, selected, bindings }) => {
 
 Stock.propTypes = {
     stock: PropTypes.shape({
-        name: PropTypes.string.isRequired,
+        name: PropTypes.string, // temporarily undefined when dragged from another window
         code: PropTypes.string.isRequired
     }).isRequired,
     bindings: PropTypes.shape({

--- a/src/child/components/favourite/Favourite.js
+++ b/src/child/components/favourite/Favourite.js
@@ -20,8 +20,6 @@ class Favourite extends Component {
         super(props);
         this.onIconClick = this.onIconClick.bind(this);
         this.onDragStart = this.onDragStart.bind(this);
-        this.onDragOver = this.onDragOver.bind(this);
-        this.onDragLeave = this.onDragLeave.bind(this);
         this.onDragEnd = this.onDragEnd.bind(this);
         this.onMouseOver = this.onMouseOver.bind(this);
         this.onMouseOut = this.onMouseOut.bind(this);
@@ -53,7 +51,7 @@ class Favourite extends Component {
         const { bindings, stockCode } = this.props;
 
         this.setState({ starTop: e.target.getBoundingClientRect().top });
-        bindings.onIconClick(stockCode);
+        bindings.onIconClick(stockCode)(e);
         e.stopPropagation();
     }
 
@@ -74,20 +72,8 @@ class Favourite extends Component {
         };
     }
 
-    onDragOver(e) {
-        e.preventDefault();
-        e.stopPropagation();
-    }
-
-    onDragLeave(e) {
-        e.currentTarget.classList.remove('dragOver');
-    }
-
     onDragEnd(e) {
         e.currentTarget.classList.remove('dragging');
-        if (e.dataTransfer.dropEffect === 'none') {
-            // TODO: Open window with stock + reposition && fade window if it's the only stock in favourites
-        }
     }
 
     onModalBackdropClick(e) {
@@ -138,12 +124,8 @@ class Favourite extends Component {
               id={`stock_${stockCode}`}
               draggable={!isUnfavouriting}
               className="favouriteWrapper"
-              onClick={() => bindings.onClick(stockCode, name)}
+              onClick={bindings.onClick(stockCode, name)}
               onDragStart={this.onDragStart(stockCode)}
-              onDragOver={this.onDragOver}
-              onDragEnter={e => bindings.dnd.onDragEnter(e, stockCode)}
-              onDragLeave={this.onDragLeave}
-              onDrop={e => bindings.dnd.onDrop(e, stockCode)}
               onDragEnd={this.onDragEnd}
               onDoubleClick={() => bindings.onDoubleClick(stockCode, name)}
               onMouseOver={this.onMouseOver}
@@ -183,10 +165,6 @@ Favourite.propTypes = {
     stockCode: PropTypes.string.isRequired,
     selected: PropTypes.bool.isRequired,
     bindings: PropTypes.shape({
-        dnd: PropTypes.shape({
-            onDragEnter: PropTypes.func.isRequired,
-            onDrop: PropTypes.func.isRequired
-        }).isRequired,
         onClick: PropTypes.func.isRequired,
         onIconClick: PropTypes.func.isRequired,
         onQuandlResponse: PropTypes.func.isRequired,

--- a/src/child/containers/sidebars/favourites/favourites.less
+++ b/src/child/containers/sidebars/favourites/favourites.less
@@ -15,10 +15,6 @@
     transition: 0.25s all;
 }
 
-.favDropTarget.dragOver #favourite-scroll {
-    background-color: #45D6BC;
-}
-
 .favouriteDropPlaceholder {
     background-color: rebeccapurple;
     height: @favourite-height;
@@ -57,6 +53,16 @@
     background-color: #2E5356;
 }
 
+.sidebars.active {
+    .favourites {
+      background-color: @highlight-colour;
+
+      .favourite, .hover-area {
+        background-color: @highlight-colour;
+      }
+    }
+}
+
 .favourites {
   float: right;
   .size(@width: @expanded-width, @height: 100%);
@@ -65,14 +71,6 @@
   &.active-add, &.active-remove {
     .favourite, .hover-area {
       .transition();
-    }
-  }
-
-  &.active {
-    background-color: @highlight-colour;
-
-    .favourite, .hover-area {
-      background-color: @highlight-colour;
     }
   }
 }

--- a/src/child/containers/sidebars/favourites/favourites.less
+++ b/src/child/containers/sidebars/favourites/favourites.less
@@ -1,4 +1,4 @@
-@favourite-height: 110px;
+@favourite-height: 109px;
 @favourite-padding-top: 10px;
 // Padding right is declared in the variables file:
 // it's used to determine the placement of other elements, while the other
@@ -28,7 +28,6 @@
     cursor: pointer;
     border-width: 1px 0;
     max-height: @favourite-height * 2;
-    transition: 0.5s padding;
     * {
         cursor: pointer;
         transition: 0.25s all;
@@ -39,7 +38,7 @@
     }
     &.dragging{
         background-color: #2B595B;
-        transition-delay: 0.25s;
+        transition-delay: 0.01s;
         transition-property: max-height, padding;
         max-height: 0;
         * {
@@ -50,6 +49,11 @@
 
 .favouriteWrapper.dragOver {
     padding-top: @favourite-height;
+    background-color: #2E5356;
+}
+
+.favouriteWrapper.dragOverBottom {
+    padding-bottom: @favourite-height;
     background-color: #2E5356;
 }
 

--- a/src/child/containers/sidebars/sidebar.less
+++ b/src/child/containers/sidebars/sidebar.less
@@ -69,6 +69,10 @@
 .sidebars {
     .size(@width: @sidebar-width, @height: 100%);
     float: left;
+
+    &.active * {
+        pointer-events: none;
+    }
 }
 .sidetab-top {
     .size(@height: @toolbar-height);


### PR DESCRIPTION
Does not include the removal of a favourite from window X when dragged from window Y as this is covered by #864.

- Dragged tile will displace another tile when it is half intersecting it (vertically)
- Dragged tile can be dropped after the final tile (rather than in the space below the final tile)
- Cleaned up the transitions
- When dragging into another window, the tile can be dropped in the sidebar regardless of whether the favourites are displayed or not