### PR TITLE
chore: quieten webpack dev build

### DIFF
--- a/webpack/webpack.config.dev.js
+++ b/webpack/webpack.config.dev.js
@@ -7,7 +7,10 @@ const config = Object.assign({}, sharedConfig, {
     devServer: {
         contentBase: './public',
         hot: true,
-        port: 5000
+        port: 5000,
+        stats: {
+            chunks: false
+        }
     }
 });
 


### PR DESCRIPTION
Turns off these messages when running webpack dev server:
![screen shot 2016-07-25 at 19 56 06](https://cloud.githubusercontent.com/assets/2017615/17113280/e020a636-52a1-11e6-91ad-970ad80bce7c.png)
