### PR TITLE
Revert "Release 10.2.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitflux-openfin",
-  "version": "10.2.0",
+  "version": "10.1.0",
   "type": "develop",
   "scripts": {
     "test": "grunt ci",

--- a/src/version-value.js
+++ b/src/version-value.js
@@ -1,7 +1,7 @@
 (function() {
     'use strict';
 
-    const VERSION = { version: '10.2.0' };
+    const VERSION = { version: '10.1.0' };
 
     angular.module('stockflux.version')
         .value('Version', VERSION.version);


### PR DESCRIPTION
Reverts ScottLogic/StockFlux#799

10.2.0 was never released, primarily due to #603 not being resolved (#626 & #666 were also unresolved, although were unlikely to have blocked the release). Given that the React/Redux rewrite will likely be released soon, this version number is being reverted.