### PR TITLE
fix: close programmatically using OpenFin window

### DIFF
--- a/src/child/containers/toolbar/Toolbar.js
+++ b/src/child/containers/toolbar/Toolbar.js
@@ -51,7 +51,7 @@ class Toolbar extends Component {
     }
 
     onCloseClick() {
-        fin.desktop.Window.getCurrent().contentWindow.close();
+        fin.desktop.Window.getCurrent().close();
     }
 
     render() {

--- a/src/parent/services/ParentService.js
+++ b/src/parent/services/ParentService.js
@@ -25,7 +25,7 @@ class ParentService {
 
         // Close the main parent window if all child windows are closed
         if (this.getChildWindowCount() === 0 && Object.keys(this.store.getState().dragOut).length === 0) {
-            fin.desktop.Window.getCurrent().contentWindow.close();
+            fin.desktop.Window.getCurrent().close();
         }
     }
 


### PR DESCRIPTION
Closing a window using `fin.desktop.Window.contentWindow.close()` does not trigger the `close-requested` event handler.

`fin.desktop.Window.close()` should be used to ensure the child window's root app component is unmounted.