### PR TITLE
chore: rollback OpenFin Runtime version to prevent maximize error

### DIFF
--- a/openfin-config/app.dev.json
+++ b/openfin-config/app.dev.json
@@ -15,7 +15,7 @@
     },
     "runtime": {
         "arguments": "--enable-aggressive-domstorage-flushing",
-        "version": "stable"
+        "version": "5.44.12.27"
     },
     "shortcut": {
         "company": "ScottLogic",

--- a/openfin-config/app.prod.json
+++ b/openfin-config/app.prod.json
@@ -15,7 +15,7 @@
     },
     "runtime": {
         "arguments": "--enable-aggressive-domstorage-flushing",
-        "version": "stable"
+        "version": "5.44.12.27"
     },
     "shortcut": {
         "company": "ScottLogic",


### PR DESCRIPTION
Rollback [OpenFin Runtime version](https://developer.openfin.co/versions/) from stable (6.49.16.16) to 5.44.12.27 to prevent maximize error, where window does not fill screen and does not resize properly.