### PR TITLE
docs: update OpenFin installer URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Here are a few things to try:
 
 ## Installing
 
-In order to install the application, download [StockFlux installer zipfile](https://dl.openfin.co/services/download?fileName=StockFlux-master&config=http://scottlogic.github.io/StockFlux/master/app.json), unzip and run the executable. If you haven't already installed an OpenFin application, this will install the required runtime. It'll also add shortcuts to StockFlux to your desktop and start menu.
+In order to install the application, download [StockFlux installer zipfile](https://install.openfin.co/download?fileName=StockFlux-master&config=http://scottlogic.github.io/StockFlux/master/app.json), unzip and run the executable. If you haven't already installed an OpenFin application, this will install the required runtime. It'll also add shortcuts to StockFlux to your desktop and start menu.
 
 This is an 'evergreen' application, each time it launches the application code is downloaded (from GitHub pages), ensuring that it is always up-to-date.
 

--- a/src/static/install.html
+++ b/src/static/install.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <script>
-    var url =  'https://dl.openfin.co/services/download?fileName=StockFlux&config=' + (location.origin + location.pathname).replace("install.html", 'app.json');
+    var url =  'https://install.openfin.co/download?fileName=StockFlux&config=' + (location.origin + location.pathname).replace("install.html", 'app.json');
     document.write('Download should start from <br />' + url);
     window.location = url;
 </script>


### PR DESCRIPTION
Update OpenFin installer link from `https://dl.openfin.co/services/download` to `https://install.openfin.co/download`.

![image](https://user-images.githubusercontent.com/2017615/33809605-7adbfdd4-ddf1-11e7-88d7-072d532962fa.png)
