### PR TITLE
fix: use QUANDL API key as environment variable in development mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The application is built using React and ES2015, transpiled via Babel. The chart
 The displayed data is real and provided by [Quandl](https://www.quandl.com). The application uses separate Quandl API keys for development and release to mitigate chances of crossing Quandl's [rate limits](https://www.quandl.com/docs/api?json#rate-limits).
 
 When working locally, make sure you set the environment variable `QUANDL_API_KEY` representing the Quandl API key before you start the development server or run a build.
-You can privately ask the key to another Stockflux developer as it is not exposed publicly.
+The key is located in the StockFlux confluence page under the Internal Systems space.
 
 ### Initial Setup
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ The application is built using React and ES2015, transpiled via Babel. The chart
 
 The displayed data is real and provided by [Quandl](https://www.quandl.com). The application uses separate Quandl API keys for development and release to mitigate chances of crossing Quandl's [rate limits](https://www.quandl.com/docs/api?json#rate-limits).
 
+When working locally, make sure you set the environment variable `QUANDL_API_KEY` representing the Quandl API key before you start the development server or run a build.
+You can privately ask the key to another Stockflux developer as it is not exposed publicly.
+
 ### Initial Setup
 
 [npm](https://www.npmjs.com/), the package manager for [Node.js](https://nodejs.org/), is used to manage the project's dependencies. [Grunt](http://gruntjs.com/), a JavaScript task runner, is used to test and build the project.

--- a/src/child/services/QuandlService.js
+++ b/src/child/services/QuandlService.js
@@ -21,7 +21,7 @@ const LOCAL_KEY = Boolean(
 const API_KEY = (
     (DEPLOY_KEY && dxor(process.env.QUANDL_API_KEY, process.env.QUANDL_KEY))
     || (LOCAL_KEY && process.env.QUANDL_API_KEY)
-    || 'kM9Z9aEULVDD7svZ4A8B'
+    || 'api_key'
 );
 const API_KEY_VALUE = `api_key=${API_KEY}`;
 const DATE_INDEX = 0;

--- a/src/child/services/QuandlService.js
+++ b/src/child/services/QuandlService.js
@@ -13,7 +13,16 @@ const DEPLOY_KEY = Boolean(process.env.TRAVIS === 'true'
     && process.env.QUANDL_API_KEY
     && process.env.QUANDL_KEY);
 
-const API_KEY = DEPLOY_KEY ? dxor(process.env.QUANDL_API_KEY, process.env.QUANDL_KEY) : 'kM9Z9aEULVDD7svZ4A8B';
+const LOCAL_KEY = Boolean(
+    process.env.TRAVIS !== 'true' &&
+    process.env.QUANDL_API_KEY
+);
+
+const API_KEY = (
+    DEPLOY_KEY && dxor(process.env.QUANDL_API_KEY, process.env.QUANDL_KEY)
+    || LOCAL_KEY && process.env.QUANDL_API_KEY
+    || 'kM9Z9aEULVDD7svZ4A8B'
+);
 const API_KEY_VALUE = `api_key=${API_KEY}`;
 const DATE_INDEX = 0;
 const OPEN_INDEX = 8;

--- a/src/child/services/QuandlService.js
+++ b/src/child/services/QuandlService.js
@@ -19,8 +19,8 @@ const LOCAL_KEY = Boolean(
 );
 
 const API_KEY = (
-    DEPLOY_KEY && dxor(process.env.QUANDL_API_KEY, process.env.QUANDL_KEY)
-    || LOCAL_KEY && process.env.QUANDL_API_KEY
+    (DEPLOY_KEY && dxor(process.env.QUANDL_API_KEY, process.env.QUANDL_KEY))
+    || (LOCAL_KEY && process.env.QUANDL_API_KEY)
     || 'kM9Z9aEULVDD7svZ4A8B'
 );
 const API_KEY_VALUE = `api_key=${API_KEY}`;

--- a/test/specs/child/services/QuandlServiceSpec.js
+++ b/test/specs/child/services/QuandlServiceSpec.js
@@ -96,9 +96,5 @@ describe('child/services/QuandlService', () => {
         it('should return a string', () => {
             expect(apiKey()).to.be.a.string;
         });
-
-        it('should return a string of length 20', () => {
-            expect(apiKey()).to.have.lengthOf(20);
-        });
     });
 });

--- a/webpack/webpack.config.dev.js
+++ b/webpack/webpack.config.dev.js
@@ -22,7 +22,8 @@ config.entry.parent.push('webpack-dev-server/client?http://localhost:5000', 'web
 config.plugins.push(
     new webpack.HotModuleReplacementPlugin(),
     new webpack.DefinePlugin({
-        'process.env.NODE_ENV': '"development"'
+        'process.env.NODE_ENV': '"development"',
+        'process.env.QUANDL_API_KEY': JSON.stringify(process.env.QUANDL_API_KEY)
     }),
     new CopyWebpackPlugin([
         { from: 'src/static' },


### PR DESCRIPTION
This PR makes `QUANDL_API_KEY` environment variable available in local (both development or production) environments.
At the moment the variable is only set automatically in Travis environment when running CI and building for deploy.