### PR TITLE
Fix linter complaints about CRLF line endings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,6 +22,7 @@
     "no-console": 0,
     "indent": ["error", 4],
     "comma-dangle" : 0,
+    "linebreak-style": 0,
     "prefer-template": 1,
     "padded-blocks": 0,
     "max-len": 0,

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 # These files are text and should be normalized (convert crlf -> lf)
 *.js      text
+*.jsx     text
 *.md      text
 *.css     text
 *.html    text

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ public
 
 #Openfin cache
 OpenFin/
+
+#IDEs
+.idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "StockFlux",
-  "version": "11.2.0",
+  "version": "12.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -17159,6 +17159,7 @@
                       "version": "2.10.1",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
                       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                      "optional": true,
                       "requires": {
                         "hoek": "2.x.x"
                       }
@@ -17584,7 +17585,8 @@
                     "lodash.tostring": {
                       "version": "4.1.2",
                       "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.2.tgz",
-                      "integrity": "sha1-fTJqXPZNpCmPL9NbaI2EgmdTUog="
+                      "integrity": "sha1-fTJqXPZNpCmPL9NbaI2EgmdTUog=",
+                      "optional": true
                     },
                     "mime-db": {
                       "version": "1.22.0",
@@ -21201,7 +21203,8 @@
                     "hoek": {
                       "version": "2.16.3",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+                      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+                      "optional": true
                     },
                     "http-signature": {
                       "version": "1.1.1",
@@ -21346,7 +21349,8 @@
                     "lodash.tostring": {
                       "version": "4.1.2",
                       "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.2.tgz",
-                      "integrity": "sha1-fTJqXPZNpCmPL9NbaI2EgmdTUog="
+                      "integrity": "sha1-fTJqXPZNpCmPL9NbaI2EgmdTUog=",
+                      "optional": true
                     },
                     "mime-db": {
                       "version": "1.22.0",


### PR DESCRIPTION
ESLint is complaining about CRLF line endings. This is because we are extending airbnb rules, which include a rule to error on non-unix line endings.

We already have a `.gitattributes` file to normalize CRLF to LF when creating a commit, and we are all developing on Windows OS, so it makes sense to override the airbnb rule.

fixes #999