### PR TITLE
Issue #728 mis-alligned close button for search in compact mode fixed.

### DIFF
--- a/src/child/containers/sidebars/search/search-compact.less
+++ b/src/child/containers/sidebars/search/search-compact.less
@@ -16,7 +16,7 @@
 
     &.expanded .close {
       background-image: url('../../../assets/png/close.png');
-      .position(relative, @top: -24px, @right: 2px);
+      .position(relative, @top: -24px, @right: 5px);
       float: right;
     }
     &.search .search-result.selected.dark {

--- a/src/child/containers/sidebars/search/search.less
+++ b/src/child/containers/sidebars/search/search.less
@@ -26,7 +26,7 @@
         .font(12px);
         color: @text-grey;
         .size(@width: 184px);
-        padding-left: 15px;
+        padding-left: 10px;
         padding-top: 16px;
         &:focus {
             outline: none;


### PR DESCRIPTION
Very basic and crude fix, increased right padding to 5 to shift the Close 'X' left, also decreased the padding of the input element so that the 'Enter stock name or symbol' is shifted slightly left as well.