### PR TITLE
Bump remotedev-server version to fix redux devtools access

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2060,7 +2060,7 @@
                 },
                 "source-map": {
                   "version": "0.5.6",
-                  "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
                   "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
                 }
               }
@@ -2203,7 +2203,7 @@
                     },
                     "source-map": {
                       "version": "0.5.6",
-                      "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
                       "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
                     }
                   }
@@ -2488,7 +2488,7 @@
                         },
                         "hash.js": {
                           "version": "1.0.3",
-                          "resolved": "http://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
                           "integrity": "sha1-EzL/ABVsCg/92CNgE9B7d6BFFXM=",
                           "requires": {
                             "inherits": "^2.0.1"
@@ -2596,7 +2596,7 @@
                         },
                         "hash.js": {
                           "version": "1.0.3",
-                          "resolved": "http://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
                           "integrity": "sha1-EzL/ABVsCg/92CNgE9B7d6BFFXM=",
                           "requires": {
                             "inherits": "^2.0.1"
@@ -2798,7 +2798,7 @@
             },
             "deps-sort": {
               "version": "2.0.0",
-              "resolved": "http://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
               "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
               "requires": {
                 "JSONStream": "^1.0.3",
@@ -2938,7 +2938,7 @@
             },
             "insert-module-globals": {
               "version": "7.0.1",
-              "resolved": "http://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.1.tgz",
               "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
               "requires": {
                 "JSONStream": "^1.0.3",
@@ -2982,7 +2982,7 @@
                     },
                     "source-map": {
                       "version": "0.5.6",
-                      "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
                       "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
                     }
                   }
@@ -3021,7 +3021,7 @@
             },
             "labeled-stream-splicer": {
               "version": "2.0.0",
-              "resolved": "http://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz",
               "integrity": "sha1-pS4dE4AkwAuGscDJH2d5GLiuClk=",
               "requires": {
                 "inherits": "^2.0.1",
@@ -3036,7 +3036,7 @@
                 },
                 "stream-splicer": {
                   "version": "2.0.0",
-                  "resolved": "http://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz",
                   "integrity": "sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=",
                   "requires": {
                     "inherits": "^2.0.1",
@@ -3116,7 +3116,7 @@
             },
             "path-browserify": {
               "version": "0.0.0",
-              "resolved": "http://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
               "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
             },
             "process": {
@@ -3185,7 +3185,7 @@
             },
             "resolve": {
               "version": "1.1.7",
-              "resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
               "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
             },
             "shasum": {
@@ -3257,7 +3257,7 @@
             },
             "stream-browserify": {
               "version": "2.0.1",
-              "resolved": "http://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
               "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
               "requires": {
                 "inherits": "~2.0.1",
@@ -3290,7 +3290,7 @@
             },
             "string_decoder": {
               "version": "0.10.31",
-              "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
             },
             "subarg": {
@@ -3310,7 +3310,7 @@
             },
             "syntax-error": {
               "version": "1.1.6",
-              "resolved": "http://registry.npmjs.org/syntax-error/-/syntax-error-1.1.6.tgz",
+              "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.6.tgz",
               "integrity": "sha1-tFSXBtOGzBwdx8JCPxhXm2yt5xA=",
               "requires": {
                 "acorn": "^2.7.0"
@@ -3334,7 +3334,7 @@
             },
             "timers-browserify": {
               "version": "1.4.2",
-              "resolved": "http://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+              "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
               "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
               "requires": {
                 "process": "~0.11.0"
@@ -3342,7 +3342,7 @@
             },
             "tty-browserify": {
               "version": "0.0.0",
-              "resolved": "http://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
               "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
             },
             "url": {
@@ -3383,7 +3383,7 @@
             },
             "vm-browserify": {
               "version": "0.0.4",
-              "resolved": "http://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
               "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
               "requires": {
                 "indexof": "0.0.1"
@@ -5165,7 +5165,7 @@
                     },
                     "cordova-registry-mapper": {
                       "version": "1.1.13",
-                      "resolved": "",
+                      "resolved": false,
                       "integrity": "sha1-COdLE4M6u0vaSyeaDUR1kBE8jCg=",
                       "requires": {
                         "tape": "^3.5.0"
@@ -6255,11 +6255,13 @@
                         },
                         "ansicolors": {
                           "version": "0.3.2",
-                          "resolved": ""
+                          "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+                          "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk="
                         },
                         "ansistyles": {
                           "version": "0.1.3",
-                          "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz"
+                          "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+                          "integrity": "sha512-6QWEyvMgIXX0eO972y7YPBLSBsq7UWKFAoNNTLGaOJ9bstcEL9sCbcjf96dVfNDdUsRoGOK82vWFJlKApXds7g=="
                         },
                         "archy": {
                           "version": "1.0.0",
@@ -6268,7 +6270,7 @@
                         },
                         "async-some": {
                           "version": "1.0.2",
-                          "resolved": "",
+                          "resolved": false,
                           "integrity": "sha1-TYqBYg1ZWHkbW5j4AtMgd3bpVQk=",
                           "requires": {
                             "dezalgo": "^1.0.2"
@@ -6360,7 +6362,7 @@
                         },
                         "dezalgo": {
                           "version": "1.0.3",
-                          "resolved": "",
+                          "resolved": false,
                           "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
                           "requires": {
                             "asap": "^2.0.0",
@@ -6409,7 +6411,7 @@
                         },
                         "fstream": {
                           "version": "1.0.10",
-                          "resolved": "",
+                          "resolved": false,
                           "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
                           "requires": {
                             "graceful-fs": "^4.1.2",
@@ -6446,7 +6448,7 @@
                         },
                         "github-url-from-username-repo": {
                           "version": "1.0.2",
-                          "resolved": "",
+                          "resolved": false,
                           "integrity": "sha1-fdeTMNKr5pwQws73lxTJchV5Hfo="
                         },
                         "glob": {
@@ -6725,7 +6727,7 @@
                         },
                         "nopt": {
                           "version": "3.0.6",
-                          "resolved": "",
+                          "resolved": false,
                           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
                           "requires": {
                             "abbrev": "1"
@@ -7001,7 +7003,8 @@
                         },
                         "path-is-inside": {
                           "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz",
+                          "integrity": "sha512-SBjqBPwe10u8a3phuxQZMZ68VZ4bHMFV8BsXf37s6+GoIjMcL4KmcOW0VGAyTuekHZdsVM79HgirZANGPFRrvg=="
                         },
                         "read": {
                           "version": "1.0.7",
@@ -7020,7 +7023,7 @@
                         },
                         "read-installed": {
                           "version": "4.0.3",
-                          "resolved": "",
+                          "resolved": false,
                           "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
                           "requires": {
                             "debuglog": "^1.0.1",
@@ -7039,7 +7042,7 @@
                             },
                             "readdir-scoped-modules": {
                               "version": "1.0.2",
-                              "resolved": "",
+                              "resolved": false,
                               "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
                               "requires": {
                                 "debuglog": "^1.0.1",
@@ -7733,7 +7736,7 @@
                         },
                         "tar": {
                           "version": "2.2.1",
-                          "resolved": "",
+                          "resolved": false,
                           "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
                           "requires": {
                             "block-stream": "*",
@@ -7743,7 +7746,8 @@
                         },
                         "text-table": {
                           "version": "0.2.0",
-                          "resolved": ""
+                          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+                          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
                         },
                         "uid-number": {
                           "version": "0.0.6",
@@ -7792,7 +7796,7 @@
                         },
                         "validate-npm-package-name": {
                           "version": "2.2.2",
-                          "resolved": "",
+                          "resolved": false,
                           "integrity": "sha1-9laVsi9zJEQgGaPH+jmm5/0pkIU=",
                           "requires": {
                             "builtins": "0.0.7"
@@ -7800,7 +7804,8 @@
                           "dependencies": {
                             "builtins": {
                               "version": "0.0.7",
-                              "resolved": ""
+                              "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
+                              "integrity": "sha1-NVIZzWzxjb58Acx/0tznZc/cVJo="
                             }
                           }
                         },
@@ -7826,7 +7831,7 @@
                         },
                         "write-file-atomic": {
                           "version": "1.1.4",
-                          "resolved": "",
+                          "resolved": false,
                           "integrity": "sha1-sfUtwujcDjywTRh6JfdYo4qQyjs=",
                           "requires": {
                             "graceful-fs": "^4.1.2",
@@ -9282,7 +9287,7 @@
                 },
                 "cordova-registry-mapper": {
                   "version": "1.1.15",
-                  "resolved": "http://registry.npmjs.org/cordova-registry-mapper/-/cordova-registry-mapper-1.1.15.tgz",
+                  "resolved": "https://registry.npmjs.org/cordova-registry-mapper/-/cordova-registry-mapper-1.1.15.tgz",
                   "integrity": "sha1-4kS5GFuBdUc7/2B5MkkFEV+D3Hw="
                 },
                 "elementtree": {
@@ -9467,7 +9472,7 @@
                 },
                 "underscore": {
                   "version": "1.8.3",
-                  "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
                   "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
                 },
                 "unorm": {
@@ -10157,7 +10162,7 @@
                                     },
                                     "hash.js": {
                                       "version": "1.0.3",
-                                      "resolved": "http://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
+                                      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
                                       "integrity": "sha1-EzL/ABVsCg/92CNgE9B7d6BFFXM=",
                                       "requires": {
                                         "inherits": "^2.0.1"
@@ -10265,7 +10270,7 @@
                                     },
                                     "hash.js": {
                                       "version": "1.0.3",
-                                      "resolved": "http://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
+                                      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
                                       "integrity": "sha1-EzL/ABVsCg/92CNgE9B7d6BFFXM=",
                                       "requires": {
                                         "inherits": "^2.0.1"
@@ -10709,7 +10714,7 @@
                         },
                         "path-browserify": {
                           "version": "0.0.0",
-                          "resolved": "http://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
                           "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
                         },
                         "process": {
@@ -10778,7 +10783,7 @@
                         },
                         "resolve": {
                           "version": "1.1.7",
-                          "resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+                          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
                           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
                         },
                         "shasum": {
@@ -10883,7 +10888,7 @@
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                         },
                         "subarg": {
@@ -10903,7 +10908,7 @@
                         },
                         "syntax-error": {
                           "version": "1.1.6",
-                          "resolved": "http://registry.npmjs.org/syntax-error/-/syntax-error-1.1.6.tgz",
+                          "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.6.tgz",
                           "integrity": "sha1-tFSXBtOGzBwdx8JCPxhXm2yt5xA=",
                           "requires": {
                             "acorn": "^2.7.0"
@@ -10927,7 +10932,7 @@
                         },
                         "timers-browserify": {
                           "version": "1.4.2",
-                          "resolved": "http://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+                          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
                           "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
                           "requires": {
                             "process": "~0.11.0"
@@ -10935,7 +10940,7 @@
                         },
                         "tty-browserify": {
                           "version": "0.0.0",
-                          "resolved": "http://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
                           "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
                         },
                         "url": {
@@ -10976,7 +10981,7 @@
                         },
                         "vm-browserify": {
                           "version": "0.0.4",
-                          "resolved": "http://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
                           "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
                           "requires": {
                             "indexof": "0.0.1"
@@ -11000,12 +11005,12 @@
                 },
                 "cordova-registry-mapper": {
                   "version": "1.1.15",
-                  "resolved": "http://registry.npmjs.org/cordova-registry-mapper/-/cordova-registry-mapper-1.1.15.tgz",
+                  "resolved": "https://registry.npmjs.org/cordova-registry-mapper/-/cordova-registry-mapper-1.1.15.tgz",
                   "integrity": "sha1-4kS5GFuBdUc7/2B5MkkFEV+D3Hw="
                 },
                 "cordova-serve": {
                   "version": "1.0.0",
-                  "resolved": "http://registry.npmjs.org/cordova-serve/-/cordova-serve-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/cordova-serve/-/cordova-serve-1.0.0.tgz",
                   "integrity": "sha1-f6HEAYPSuCrbeS+cueDVVKI+7YU=",
                   "requires": {
                     "chalk": "^1.1.1",
@@ -11230,7 +11235,7 @@
                         },
                         "array-flatten": {
                           "version": "1.1.1",
-                          "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
                           "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
                         },
                         "content-disposition": {
@@ -11432,7 +11437,7 @@
                             },
                             "mime": {
                               "version": "1.3.4",
-                              "resolved": "http://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+                              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
                               "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
                             },
                             "ms": {
@@ -11518,7 +11523,7 @@
                   "dependencies": {
                     "underscore": {
                       "version": "1.2.1",
-                      "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.2.1.tgz",
+                      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.2.1.tgz",
                       "integrity": "sha1-/FxrB2VnPZKi1KyLTcCqiHAuK9Q="
                     }
                   }
@@ -11994,11 +11999,13 @@
                     },
                     "ansicolors": {
                       "version": "0.3.2",
-                      "resolved": ""
+                      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+                      "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk="
                     },
                     "ansistyles": {
                       "version": "0.1.3",
-                      "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz"
+                      "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+                      "integrity": "sha512-6QWEyvMgIXX0eO972y7YPBLSBsq7UWKFAoNNTLGaOJ9bstcEL9sCbcjf96dVfNDdUsRoGOK82vWFJlKApXds7g=="
                     },
                     "archy": {
                       "version": "1.0.0",
@@ -12007,6 +12014,7 @@
                     },
                     "async-some": {
                       "version": "1.0.2",
+                      "resolved": false,
                       "integrity": "sha1-TYqBYg1ZWHkbW5j4AtMgd3bpVQk=",
                       "requires": {
                         "dezalgo": "^1.0.2"
@@ -12098,6 +12106,7 @@
                     },
                     "dezalgo": {
                       "version": "1.0.3",
+                      "resolved": false,
                       "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
                       "requires": {
                         "asap": "^2.0.0",
@@ -12183,6 +12192,7 @@
                     },
                     "github-url-from-username-repo": {
                       "version": "1.0.2",
+                      "resolved": false,
                       "integrity": "sha1-fdeTMNKr5pwQws73lxTJchV5Hfo="
                     },
                     "glob": {
@@ -12461,6 +12471,7 @@
                     },
                     "nopt": {
                       "version": "3.0.6",
+                      "resolved": false,
                       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
                       "requires": {
                         "abbrev": "1"
@@ -12736,7 +12747,8 @@
                     },
                     "path-is-inside": {
                       "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz",
+                      "integrity": "sha512-SBjqBPwe10u8a3phuxQZMZ68VZ4bHMFV8BsXf37s6+GoIjMcL4KmcOW0VGAyTuekHZdsVM79HgirZANGPFRrvg=="
                     },
                     "read": {
                       "version": "1.0.7",
@@ -12755,6 +12767,7 @@
                     },
                     "read-installed": {
                       "version": "4.0.3",
+                      "resolved": false,
                       "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
                       "requires": {
                         "debuglog": "^1.0.1",
@@ -12773,6 +12786,7 @@
                         },
                         "readdir-scoped-modules": {
                           "version": "1.0.2",
+                          "resolved": false,
                           "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
                           "requires": {
                             "debuglog": "^1.0.1",
@@ -13466,6 +13480,7 @@
                     },
                     "tar": {
                       "version": "2.2.1",
+                      "resolved": false,
                       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
                       "requires": {
                         "block-stream": "*",
@@ -13475,7 +13490,8 @@
                     },
                     "text-table": {
                       "version": "0.2.0",
-                      "resolved": ""
+                      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+                      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
                     },
                     "uid-number": {
                       "version": "0.0.6",
@@ -13524,6 +13540,7 @@
                     },
                     "validate-npm-package-name": {
                       "version": "2.2.2",
+                      "resolved": false,
                       "integrity": "sha1-9laVsi9zJEQgGaPH+jmm5/0pkIU=",
                       "requires": {
                         "builtins": "0.0.7"
@@ -13531,7 +13548,8 @@
                       "dependencies": {
                         "builtins": {
                           "version": "0.0.7",
-                          "resolved": ""
+                          "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
+                          "integrity": "sha1-NVIZzWzxjb58Acx/0tznZc/cVJo="
                         }
                       }
                     },
@@ -13557,6 +13575,7 @@
                     },
                     "write-file-atomic": {
                       "version": "1.1.4",
+                      "resolved": false,
                       "integrity": "sha1-sfUtwujcDjywTRh6JfdYo4qQyjs=",
                       "requires": {
                         "graceful-fs": "^4.1.2",
@@ -13683,7 +13702,7 @@
                             },
                             "string_decoder": {
                               "version": "0.10.31",
-                              "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                               "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                             }
                           }
@@ -13732,7 +13751,7 @@
                         },
                         "mime": {
                           "version": "1.2.11",
-                          "resolved": "http://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+                          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
                           "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
                         }
                       }
@@ -13828,7 +13847,7 @@
                     },
                     "qs": {
                       "version": "2.3.3",
-                      "resolved": "http://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
                       "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ="
                     },
                     "stringstream": {
@@ -14937,7 +14956,7 @@
             },
             "underscore": {
               "version": "1.7.0",
-              "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
               "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
             },
             "update-notifier": {
@@ -15234,7 +15253,7 @@
                                     },
                                     "string_decoder": {
                                       "version": "0.10.31",
-                                      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                                       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                                     },
                                     "util-deprecate": {
@@ -15361,7 +15380,7 @@
                                     },
                                     "string_decoder": {
                                       "version": "0.10.31",
-                                      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                                       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                                     },
                                     "util-deprecate": {
@@ -15759,7 +15778,7 @@
         },
         "grunt": {
           "version": "0.4.5",
-          "resolved": "http://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+          "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
           "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
           "requires": {
             "async": "~0.1.22",
@@ -15791,7 +15810,7 @@
             },
             "coffee-script": {
               "version": "1.3.3",
-              "resolved": "http://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+              "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
               "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ="
             },
             "colors": {
@@ -15848,7 +15867,7 @@
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.7.3",
-                          "resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
                           "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
                         },
                         "sigmund": {
@@ -15972,7 +15991,7 @@
                   "dependencies": {
                     "underscore": {
                       "version": "1.7.0",
-                      "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+                      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
                       "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
                     },
                     "underscore.string": {
@@ -16005,7 +16024,7 @@
               "dependencies": {
                 "lru-cache": {
                   "version": "2.7.3",
-                  "resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
                   "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
                 },
                 "sigmund": {
@@ -16371,7 +16390,7 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                     },
                     "util-deprecate": {
@@ -16587,7 +16606,7 @@
             },
             "pretty-bytes": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/pretty-bytes/-/pretty-bytes-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-3.0.1.tgz",
               "integrity": "sha1-J9AAjXeAY6C0gRuzXHnxvV1fvM8=",
               "requires": {
                 "number-is-nan": "^1.0.0"
@@ -16677,7 +16696,7 @@
             },
             "source-map": {
               "version": "0.5.6",
-              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
               "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
             }
           }
@@ -17095,7 +17114,7 @@
                     },
                     "mime": {
                       "version": "1.3.4",
-                      "resolved": "http://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+                      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
                       "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
                     },
                     "ms": {
@@ -17332,7 +17351,7 @@
                 },
                 "mime": {
                   "version": "1.3.4",
-                  "resolved": "http://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
                   "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
                   "optional": true
                 },
@@ -17372,7 +17391,7 @@
                 },
                 "source-map": {
                   "version": "0.5.6",
-                  "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
                   "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
                   "optional": true
                 }
@@ -17562,7 +17581,7 @@
                             },
                             "string_decoder": {
                               "version": "0.10.31",
-                              "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                               "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                             },
                             "util-deprecate": {
@@ -17583,7 +17602,7 @@
                 },
                 "pretty-bytes": {
                   "version": "1.0.4",
-                  "resolved": "http://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
                   "integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
                   "requires": {
                     "get-stdin": "^4.0.1",
@@ -18004,7 +18023,7 @@
                 },
                 "source-map": {
                   "version": "0.5.6",
-                  "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
                   "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
                 },
                 "uglify-to-browserify": {
@@ -18394,7 +18413,7 @@
                     },
                     "qs": {
                       "version": "5.2.0",
-                      "resolved": "http://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
                       "integrity": "sha1-qfMRQq9GjLcrJbMBNrokVoNJFr4="
                     },
                     "raw-body": {
@@ -18504,7 +18523,7 @@
                 },
                 "qs": {
                   "version": "5.1.0",
-                  "resolved": "http://registry.npmjs.org/qs/-/qs-5.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz",
                   "integrity": "sha1-TZMuXH6kEcynajEtOaYGIA/VDNk="
                 }
               }
@@ -18669,7 +18688,7 @@
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                         },
                         "util-deprecate": {
@@ -19442,7 +19461,7 @@
                       "dependencies": {
                         "sprintf-js": {
                           "version": "1.0.3",
-                          "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
                           "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
                         }
                       }
@@ -19595,7 +19614,7 @@
                       "dependencies": {
                         "callsites": {
                           "version": "0.2.0",
-                          "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+                          "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
                           "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
                         }
                       }
@@ -19781,7 +19800,7 @@
                 },
                 "mime": {
                   "version": "1.2.11",
-                  "resolved": "http://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
                   "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
                 },
                 "mimeparse": {
@@ -19791,7 +19810,7 @@
                 },
                 "qs": {
                   "version": "0.1.0",
-                  "resolved": "http://registry.npmjs.org/qs/-/qs-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-0.1.0.tgz",
                   "integrity": "sha1-mg0tcNAfY9NAHqSwUIImAbRi7ms="
                 },
                 "url2": {
@@ -19940,7 +19959,7 @@
             },
             "prettysize": {
               "version": "0.0.3",
-              "resolved": "http://registry.npmjs.org/prettysize/-/prettysize-0.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/prettysize/-/prettysize-0.0.3.tgz",
               "integrity": "sha1-FK//amReWRpN3xxykZwjtBRhgaE="
             },
             "svg-sprite": {
@@ -20102,7 +20121,7 @@
                       "dependencies": {
                         "sprintf-js": {
                           "version": "1.0.3",
-                          "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
                           "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
                         }
                       }
@@ -21000,7 +21019,7 @@
                           "dependencies": {
                             "sprintf-js": {
                               "version": "1.0.3",
-                              "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                              "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
                               "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
                             }
                           }
@@ -22058,7 +22077,7 @@
                 },
                 "source-map": {
                   "version": "0.2.0",
-                  "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
                   "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
                   "optional": true,
                   "requires": {
@@ -22216,7 +22235,7 @@
                     },
                     "source-map": {
                       "version": "0.4.4",
-                      "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                       "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                       "requires": {
                         "amdefine": ">=0.0.4"
@@ -22249,7 +22268,7 @@
                         },
                         "source-map": {
                           "version": "0.5.6",
-                          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
                           "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
                           "optional": true
                         },
@@ -22446,7 +22465,7 @@
                       "dependencies": {
                         "sprintf-js": {
                           "version": "1.0.3",
-                          "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
                           "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
                         }
                       }
@@ -22478,7 +22497,7 @@
                 },
                 "resolve": {
                   "version": "1.1.7",
-                  "resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
                   "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
                 },
                 "supports-color": {
@@ -22556,7 +22575,7 @@
                 },
                 "underscore": {
                   "version": "1.6.0",
-                  "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
                   "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
                 }
               }
@@ -22568,7 +22587,7 @@
             },
             "source-map": {
               "version": "0.5.6",
-              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
               "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
             },
             "which": {
@@ -22874,7 +22893,7 @@
                           "dependencies": {
                             "expand-range": {
                               "version": "1.8.2",
-                              "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+                              "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
                               "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
                               "requires": {
                                 "fill-range": "^2.1.0"
@@ -23184,7 +23203,7 @@
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                         },
                         "util-deprecate": {
@@ -23363,7 +23382,7 @@
                   "dependencies": {
                     "expand-range": {
                       "version": "0.1.1",
-                      "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
                       "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
                       "requires": {
                         "is-number": "^0.1.1",
@@ -23520,7 +23539,7 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                     }
                   }
@@ -23534,7 +23553,7 @@
             },
             "mime": {
               "version": "1.3.4",
-              "resolved": "http://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
               "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
             },
             "minimatch": {
@@ -24046,7 +24065,7 @@
             },
             "source-map": {
               "version": "0.5.6",
-              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
               "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
             },
             "useragent": {
@@ -24059,7 +24078,7 @@
               "dependencies": {
                 "lru-cache": {
                   "version": "2.2.4",
-                  "resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
                   "integrity": "sha1-bGWGGb7PFAMdDQtZSxYELOTcBj0="
                 }
               }
@@ -24695,7 +24714,7 @@
                     },
                     "source-map": {
                       "version": "0.2.0",
-                      "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
                       "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
                       "optional": true,
                       "requires": {
@@ -24791,7 +24810,7 @@
                     },
                     "source-map": {
                       "version": "0.4.4",
-                      "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                       "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                       "requires": {
                         "amdefine": ">=0.0.4"
@@ -24824,7 +24843,7 @@
                         },
                         "source-map": {
                           "version": "0.5.6",
-                          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
                           "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
                           "optional": true
                         },
@@ -25021,7 +25040,7 @@
                       "dependencies": {
                         "sprintf-js": {
                           "version": "1.0.3",
-                          "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
                           "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
                         }
                       }
@@ -25068,7 +25087,7 @@
                 },
                 "resolve": {
                   "version": "1.1.7",
-                  "resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
                   "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
                 },
                 "supports-color": {
@@ -25146,7 +25165,7 @@
             },
             "source-map": {
               "version": "0.5.6",
-              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
               "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
             }
           }
@@ -25305,7 +25324,7 @@
                 },
                 "source-map": {
                   "version": "0.5.6",
-                  "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
                   "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
                 },
                 "supports-color": {
@@ -25490,7 +25509,7 @@
         },
         "watchify": {
           "version": "3.7.0",
-          "resolved": "http://registry.npmjs.org/watchify/-/watchify-3.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/watchify/-/watchify-3.7.0.tgz",
           "integrity": "sha1-7i8sXIw3MSMD+Zi4GLKzRQ7v5kg=",
           "requires": {
             "anymatch": "^1.3.0",
@@ -25568,7 +25587,7 @@
                       "dependencies": {
                         "expand-range": {
                           "version": "1.8.2",
-                          "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+                          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
                           "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
                           "requires": {
                             "fill-range": "^2.1.0"
@@ -25948,7 +25967,7 @@
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                         },
                         "util-deprecate": {
@@ -26065,7 +26084,7 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                     },
                     "util-deprecate": {
@@ -26229,11 +26248,117 @@
         "normalize-path": "^2.1.1"
       }
     },
+    "apollo-cache-control": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.1.1.tgz",
+      "integrity": "sha512-XJQs167e9u+e5ybSi51nGYr70NPBbswdvTEHtbtXbwkZ+n9t0SLPvUcoqceayOSwjK1XYOdU/EKPawNdb3rLQA==",
+      "dev": true,
+      "requires": {
+        "graphql-extensions": "^0.0.x"
+      }
+    },
+    "apollo-link": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.4.tgz",
+      "integrity": "sha512-B1z+9H2nTyWEhMXRFSnoZ1vSuAYP+V/EdUJvRx9uZ8yuIBZMm6reyVtr1n0BWlKeSFyPieKJy2RLzmITAAQAMQ==",
+      "dev": true,
+      "requires": {
+        "apollo-utilities": "^1.0.0",
+        "zen-observable-ts": "^0.8.11"
+      }
+    },
+    "apollo-server-core": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-1.4.0.tgz",
+      "integrity": "sha512-BP1Vh39krgEjkQxbjTdBURUjLHbFq1zeOChDJgaRsMxGtlhzuLWwwC6lLdPatN8jEPbeHq8Tndp9QZ3iQZOKKA==",
+      "dev": true,
+      "requires": {
+        "apollo-cache-control": "^0.1.0",
+        "apollo-tracing": "^0.1.0",
+        "graphql-extensions": "^0.0.x"
+      }
+    },
+    "apollo-server-express": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-1.4.0.tgz",
+      "integrity": "sha512-zkH00nxhLnJfO0HgnNPBTfZw8qI5ILaPZ5TecMCI9+Y9Ssr2b0bFr9pBRsXy9eudPhI+/O4yqegSUsnLdF/CPw==",
+      "dev": true,
+      "requires": {
+        "apollo-server-core": "^1.4.0",
+        "apollo-server-module-graphiql": "^1.4.0"
+      }
+    },
+    "apollo-server-module-graphiql": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-module-graphiql/-/apollo-server-module-graphiql-1.4.0.tgz",
+      "integrity": "sha512-GmkOcb5he2x5gat+TuiTvabnBf1m4jzdecal3XbXBh/Jg+kx4hcvO3TTDFQ9CuTprtzdcVyA11iqG7iOMOt7vA==",
+      "dev": true
+    },
+    "apollo-tracing": {
+      "version": "0.1.4",
+      "resolved": "http://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.1.4.tgz",
+      "integrity": "sha512-Uv+1nh5AsNmC3m130i2u3IqbS+nrxyVV3KYimH5QKsdPjxxIQB3JAT+jJmpeDxBel8gDVstNmCh82QSLxLSIdQ==",
+      "dev": true,
+      "requires": {
+        "graphql-extensions": "~0.0.9"
+      }
+    },
+    "apollo-utilities": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.26.tgz",
+      "integrity": "sha512-URw7o3phymliqYCYatcird2YRPUU2eWCNvip64U9gQrX56mEfK4m99yBIDCMTpmcvOFsKLii1sIEZsHIs/bvnw==",
+      "dev": true,
+      "requires": {
+        "fast-json-stable-stringify": "^2.0.0"
+      }
+    },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "dev": true,
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
     },
     "argparse": {
       "version": "1.0.10",
@@ -26400,6 +26525,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+      "dev": true
+    },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
       "dev": true
     },
     "asynckit": {
@@ -26862,10 +26993,19 @@
       "dev": true
     },
     "base64id": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
-      "integrity": "sha1-As4P3u4M709ACA4ec+g08LG/zj8=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
+      "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
       "dev": true
+    },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
     },
     "batch": {
       "version": "0.6.1",
@@ -27298,6 +27438,12 @@
         "supports-color": "^5.3.0"
       }
     },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
+    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
@@ -27620,6 +27766,12 @@
       "requires": {
         "date-now": "^0.1.4"
       }
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "dev": true
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -28172,6 +28324,12 @@
       "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
       "dev": true
     },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true
+    },
     "deep-freeze": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/deep-freeze/-/deep-freeze-0.0.1.tgz",
@@ -28286,10 +28444,22 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true
+    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
+    },
+    "deprecated-decorator": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz",
+      "integrity": "sha1-AJZjF7ehL+kvPMgx91g68ym4bDc=",
       "dev": true
     },
     "des.js": {
@@ -28322,6 +28492,12 @@
       "requires": {
         "repeating": "^2.0.0"
       }
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+      "dev": true
     },
     "detect-node": {
       "version": "2.0.4",
@@ -29315,14 +29491,14 @@
       }
     },
     "external-editor": {
-      "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
-      "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
+      "version": "2.2.0",
+      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
-        "extend": "^3.0.0",
-        "spawn-sync": "^1.0.15",
-        "tmp": "^0.0.29"
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
+        "tmp": "^0.0.33"
       }
     },
     "extglob": {
@@ -29648,9 +29824,9 @@
       }
     },
     "fleximap": {
-      "version": "0.9.10",
-      "resolved": "http://registry.npmjs.org/fleximap/-/fleximap-0.9.10.tgz",
-      "integrity": "sha1-GqUP9qj+oAN8w3jjjdrMCRAlrBA=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fleximap/-/fleximap-1.0.0.tgz",
+      "integrity": "sha512-zg/PthjBzESYKomTw/wivo8Id6B+obVkWriIzDuRfuw4wxEIV2/0D/NIGf+LKcGTTifHRfw73+oAAQozZ9MAhA==",
       "dev": true
     },
     "flush-write-stream": {
@@ -29824,13 +30000,14 @@
       }
     },
     "fs-extra": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.0.0.tgz",
-      "integrity": "sha1-M3NSve1KC3FPPrhN6M6nZenTdgA=",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
+      "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
-        "jsonfile": "^2.1.0"
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       },
       "dependencies": {
         "graceful-fs": {
@@ -29839,6 +30016,15 @@
           "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
           "dev": true
         }
+      }
+    },
+    "fs-minipass": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+      "dev": true,
+      "requires": {
+        "minipass": "^2.2.1"
       }
     },
     "fs-write-stream-atomic": {
@@ -29920,7 +30106,8 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
@@ -29929,7 +30116,8 @@
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -30032,7 +30220,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -30042,6 +30231,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -30066,6 +30256,7 @@
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -30154,7 +30345,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -30164,6 +30356,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -30269,6 +30462,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -30348,6 +30542,22 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      }
     },
     "generate-function": {
       "version": "2.3.1",
@@ -30497,6 +30707,55 @@
         "natives": "^1.1.0"
       }
     },
+    "graphql": {
+      "version": "0.13.2",
+      "resolved": "http://registry.npmjs.org/graphql/-/graphql-0.13.2.tgz",
+      "integrity": "sha512-QZ5BL8ZO/B20VA8APauGBg3GyEgZ19eduvpLWoq5x7gMmWnHoy8rlQWPLmWgFvo1yNgjSEFMesmS4R6pPr7xog==",
+      "dev": true,
+      "requires": {
+        "iterall": "^1.2.1"
+      }
+    },
+    "graphql-extensions": {
+      "version": "0.0.10",
+      "resolved": "http://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.0.10.tgz",
+      "integrity": "sha512-TnQueqUDCYzOSrpQb3q1ngDSP2otJSF+9yNLrQGPzkMsvnQ+v6e2d5tl+B35D4y+XpmvVnAn4T3ZK28mkILveA==",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.5.3",
+        "source-map-support": "^0.5.1"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.0.tgz",
+          "integrity": "sha512-kLRC6ncVpuEW/1kwrOXYX6KQASCVtrh1gQr/UiaVgFlf9WE5Vp+lNe5+h3LuMr5PAucWnnEXwH0nQHRH/gpGtw==",
+          "dev": true
+        }
+      }
+    },
+    "graphql-server-express": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphql-server-express/-/graphql-server-express-1.4.0.tgz",
+      "integrity": "sha512-KdFI03IhogEDmH0QMUeG8lpGe+yR+M+9HDNAiHrkt8QD/1PbHDqlYxZ5hY/mR9Mzk4O3bRcsRkYIm+UrvX4HMA==",
+      "dev": true,
+      "requires": {
+        "apollo-server-express": "^1.4.0"
+      }
+    },
+    "graphql-tools": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-4.0.3.tgz",
+      "integrity": "sha512-NNZM0WSnVLX1zIMUxu7SjzLZ4prCp15N5L2T2ro02OVyydZ0fuCnZYRnx/yK9xjGWbZA0Q58yEO//Bv/psJWrg==",
+      "dev": true,
+      "requires": {
+        "apollo-link": "^1.2.3",
+        "apollo-utilities": "^1.0.1",
+        "deprecated-decorator": "^0.1.6",
+        "iterall": "^1.1.3",
+        "uuid": "^3.1.0"
+      }
+    },
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
@@ -30611,6 +30870,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
     "has-value": {
@@ -30905,17 +31170,21 @@
       "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
       "dev": true
     },
+    "ignore-walk": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
+    },
     "image-size": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
       "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
       "dev": true,
       "optional": true
-    },
-    "immutable": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
-      "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
     },
     "import-local": {
       "version": "2.0.0",
@@ -31417,12 +31686,6 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
-    "isemail": {
-      "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
-      "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo=",
-      "dev": true
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -31567,17 +31830,11 @@
         }
       }
     },
-    "joi": {
-      "version": "6.10.1",
-      "resolved": "http://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
-      "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.x.x",
-        "isemail": "1.x.x",
-        "moment": "2.x.x",
-        "topo": "1.x.x"
-      }
+    "iterall": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
+      "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==",
+      "dev": true
     },
     "jquery": {
       "version": "1.12.4",
@@ -31720,9 +31977,9 @@
       }
     },
     "jsonfile": {
-      "version": "2.4.0",
-      "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
@@ -31748,6 +32005,23 @@
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
+    },
+    "jsonwebtoken": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.4.0.tgz",
+      "integrity": "sha512-coyXjRTCy0pw5WYBpMvWOMN+Kjaik2MwTUIq9cna/W7NpO9E+iYbumZONAz3hcr+tXFJECoQVrtmIoC3Oz0gvg==",
+      "dev": true,
+      "requires": {
+        "jws": "^3.1.5",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1"
+      }
     },
     "jsprim": {
       "version": "1.4.1",
@@ -31798,6 +32072,70 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
       "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
       "dev": true
+    },
+    "knex": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-0.15.2.tgz",
+      "integrity": "sha1-YFm4dIlgX0zIdZmm0qnSZXCek0A=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "bluebird": "^3.5.1",
+        "chalk": "2.3.2",
+        "commander": "^2.16.0",
+        "debug": "3.1.0",
+        "inherits": "~2.0.3",
+        "interpret": "^1.1.0",
+        "liftoff": "2.5.0",
+        "lodash": "^4.17.10",
+        "minimist": "1.2.0",
+        "mkdirp": "^0.5.1",
+        "pg-connection-string": "2.0.0",
+        "tarn": "^1.1.4",
+        "tildify": "1.2.0",
+        "uuid": "^3.3.2",
+        "v8flags": "^3.1.1"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.3.2",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
     },
     "lcid": {
       "version": "2.0.0",
@@ -32156,6 +32494,12 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
+      "dev": true
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -32168,10 +32512,34 @@
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
+      "dev": true
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
+      "dev": true
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=",
+      "dev": true
+    },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
       "dev": true
     },
     "lodash.keys": {
@@ -32449,6 +32817,33 @@
       "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
+    "minipass": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true
+        }
+      }
+    },
+    "minizlib": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+      "dev": true,
+      "requires": {
+        "minipass": "^2.2.1"
+      }
+    },
     "mississippi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
@@ -32572,6 +32967,36 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
       "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
     },
+    "morgan": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
+      "integrity": "sha512-HQStPIV4y3afTiCYVxirakhlCfGkI161c76kKFca7Fk1JusM//Qeo1ej2XaMniiNeaZklMVrh3vTtIzpzwbpmA==",
+      "dev": true,
+      "requires": {
+        "basic-auth": "~2.0.0",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -32651,19 +33076,46 @@
       "dev": true
     },
     "ncom": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/ncom/-/ncom-0.11.2.tgz",
-      "integrity": "sha512-3G4srxgnqLzlZuHB/jQd+ihOQEmy3lNB7wmWwzLGmaYQXuqMpMbKC21CGSAMq0gd2KFwjf8ofZ9kWS2OHQZE8Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ncom/-/ncom-1.0.3.tgz",
+      "integrity": "sha512-PfA7rjxxMAItsGo2qXrGn2GvKJIwN0bUTa3GehsblrKRVdCCEwB0QG2ymM6/DppQGUt7YqbfxQB7LaMWMiHHWQ==",
       "dev": true,
       "requires": {
-        "sc-domain": "1.x.x",
-        "sc-formatter": "3.0.x"
+        "sc-formatter": "~3.0.1"
       },
       "dependencies": {
         "sc-formatter": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/sc-formatter/-/sc-formatter-3.0.2.tgz",
           "integrity": "sha512-9PbqYBpCq+OoEeRQ3QfFIGE6qwjjBcd2j7UjgDlhnZbtSnuGgHdcRklPKYGuYFH82V/dwd+AIpu8XvA1zqTd+A==",
+          "dev": true
+        }
+      }
+    },
+    "needle": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.4.tgz",
+      "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.1.2",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
       }
@@ -32864,6 +33316,24 @@
       "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
       "dev": true
     },
+    "node-pre-gyp": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz",
+      "integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
+      "dev": true,
+      "requires": {
+        "detect-libc": "^1.0.2",
+        "mkdirp": "^0.5.1",
+        "needle": "^2.2.1",
+        "nopt": "^4.0.1",
+        "npm-packlist": "^1.1.6",
+        "npmlog": "^4.0.2",
+        "rc": "^1.2.7",
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar": "^4"
+      }
+    },
     "node-releases": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.3.tgz",
@@ -32939,6 +33409,22 @@
         "remove-trailing-separator": "^1.0.1"
       }
     },
+    "npm-bundled": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.5.tgz",
+      "integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==",
+      "dev": true
+    },
+    "npm-packlist": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.12.tgz",
+      "integrity": "sha512-WJKFOVMeAlsU/pjXuqVdzU0WfgtIBCupkEVwn+1Y0ERAbUfWw8R4GjgVbaKnUjRoD2FoQbHOCbOyT5Mbs9Lw4g==",
+      "dev": true,
+      "requires": {
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1"
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -32946,6 +33432,18 @@
       "dev": true,
       "requires": {
         "path-key": "^2.0.0"
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "dev": true,
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "number-is-nan": {
@@ -33219,12 +33717,6 @@
         "mem": "^4.0.0"
       }
     },
-    "os-shim": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
-      "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=",
-      "dev": true
-    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -33494,6 +33986,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "pg-connection-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.0.0.tgz",
+      "integrity": "sha1-Pu/lmX4G2Ugh5NUC5CtqHHP434I=",
+      "dev": true
     },
     "pify": {
       "version": "3.0.0",
@@ -33839,6 +34337,26 @@
       "integrity": "sha1-DD0L6u2KAclm2Xh793goElKpeao=",
       "dev": true
     },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
     "react": {
       "version": "15.6.2",
       "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
@@ -34163,9 +34681,9 @@
       }
     },
     "remotedev-server": {
-      "version": "0.1.8",
-      "resolved": "http://registry.npmjs.org/remotedev-server/-/remotedev-server-0.1.8.tgz",
-      "integrity": "sha1-gYev/JbJQlm33SpK018m/szVA08=",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/remotedev-server/-/remotedev-server-0.3.1.tgz",
+      "integrity": "sha512-EXgfeTEem2BJOZOkuU/uPiLumgSy1BkXtk0tnvJTeA91TuQ1Q0ipCWZsqBYxSq6CdH4BseuLvLQSbKgrvzzs6w==",
       "dev": true,
       "requires": {
         "body-parser": "^1.15.0",
@@ -34174,11 +34692,17 @@
         "ejs": "^2.4.1",
         "express": "^4.13.3",
         "getport": "^0.1.0",
+        "graphql": "^0.13.0",
+        "graphql-server-express": "^1.4.0",
+        "graphql-tools": "^4.0.3",
+        "knex": "^0.15.2",
+        "lodash": "^4.15.0",
         "minimist": "^1.2.0",
-        "object-assign": "^4.0.0",
-        "repeat-string": "^1.5.4",
+        "morgan": "^1.7.0",
         "semver": "^5.3.0",
-        "socketcluster": "^5.0.4"
+        "socketcluster": "^14.3.3",
+        "sqlite3": "^4.0.4",
+        "uuid": "^3.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -34199,6 +34723,12 @@
             "strip-ansi": "^3.0.0",
             "supports-color": "^2.0.0"
           }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
         },
         "minimist": {
           "version": "1.2.0",
@@ -34406,17 +34936,28 @@
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
       "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
     },
-    "rx": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
-      "dev": true
-    },
     "rx-lite": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
       "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
       "dev": true
+    },
+    "rxjs": {
+      "version": "5.5.12",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
+      "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "1.0.1"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+          "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+          "dev": true
+        }
+      }
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -34450,13 +34991,13 @@
       "dev": true
     },
     "sc-auth": {
-      "version": "4.1.3",
-      "resolved": "http://registry.npmjs.org/sc-auth/-/sc-auth-4.1.3.tgz",
-      "integrity": "sha512-qNXHiEnc4u7R0uSDtXIuUa9jqfsRB4UTHIo4Sx4+P6TZ3skPM6P6QVFkM8/E5bVls5/9LSGudIAqkTG3ZQ6rdg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sc-auth/-/sc-auth-5.0.2.tgz",
+      "integrity": "sha512-Le3YBsFjzv5g6wIH6Y+vD+KFkK0HDXiaWy1Gm4nXtYebMQUyNYSf1cS83MtHrYzVEMlhYElRva1b0bvZ0hBqQw==",
       "dev": true,
       "requires": {
-        "sc-errors": "^1.4.0",
-        "sc-jsonwebtoken": "^7.4.2"
+        "jsonwebtoken": "^8.3.0",
+        "sc-errors": "^1.4.1"
       },
       "dependencies": {
         "sc-errors": {
@@ -34468,38 +35009,59 @@
       }
     },
     "sc-broker": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/sc-broker/-/sc-broker-3.0.0.tgz",
-      "integrity": "sha1-o0SRgWvcKq9vI1YslC65UF61R30=",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/sc-broker/-/sc-broker-6.0.0.tgz",
+      "integrity": "sha512-c1mFIllUdPnEXDDFxTiX3obYW+cT0hb56fdNM5k+Xo5DI3+3Q9MYxTc8jD23qBIXOHokt4+d/CHocmZQPlAjAQ==",
       "dev": true,
       "requires": {
-        "expirymanager": "~0.9.3",
-        "fleximap": "~0.9.10",
-        "ncom": "~0.11.1",
-        "sc-domain": "~1.0.1",
-        "sc-errors": "~1.3.0"
+        "async": "^2.6.1",
+        "expirymanager": "^0.9.3",
+        "fleximap": "^1.0.0",
+        "ncom": "^1.0.2",
+        "sc-errors": "^1.4.1",
+        "uuid": "3.1.0"
       },
       "dependencies": {
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.10"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        },
         "sc-errors": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/sc-errors/-/sc-errors-1.3.3.tgz",
-          "integrity": "sha1-wAvEx2apcMyNWTfQjNWOkx19rgU=",
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/sc-errors/-/sc-errors-1.4.1.tgz",
+          "integrity": "sha512-dBn92iIonpChTxYLgKkIT/PCApvmYT6EPIbRvbQKTgY6tbEbIy8XVUv4pGyKwEK4nCmvX4TKXcN0iXC6tNW6rQ==",
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
           "dev": true
         }
       }
     },
     "sc-broker-cluster": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/sc-broker-cluster/-/sc-broker-cluster-4.0.3.tgz",
-      "integrity": "sha1-WcA7McOW30QQ5tGYulDsB0BQjw8=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/sc-broker-cluster/-/sc-broker-cluster-7.0.0.tgz",
+      "integrity": "sha512-DNG8sxiFwmRSMS0sUXA25UvDV8QTwEfYnzrutqbp4HlMU9JP65FBcs6GuNFPhjQN4s9VtwAE8BBaCNK5BjNV0g==",
       "dev": true,
       "requires": {
         "async": "2.0.0",
-        "sc-broker": "~3.0.0",
-        "sc-channel": "~1.0.6",
-        "sc-domain": "~1.0.1",
-        "sc-errors": "~1.3.0",
-        "sc-hasher": "~1.0.0"
+        "sc-broker": "^6.0.0",
+        "sc-channel": "^1.2.0",
+        "sc-errors": "^1.4.1",
+        "sc-hasher": "^1.0.1"
       },
       "dependencies": {
         "async": {
@@ -34517,10 +35079,19 @@
           "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
           "dev": true
         },
+        "sc-channel": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/sc-channel/-/sc-channel-1.2.0.tgz",
+          "integrity": "sha512-M3gdq8PlKg0zWJSisWqAsMmTVxYRTpVRqw4CWAdKBgAfVKumFcTjoCV0hYu7lgUXccCtCD8Wk9VkkE+IXCxmZA==",
+          "dev": true,
+          "requires": {
+            "component-emitter": "1.2.1"
+          }
+        },
         "sc-errors": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/sc-errors/-/sc-errors-1.3.3.tgz",
-          "integrity": "sha1-wAvEx2apcMyNWTfQjNWOkx19rgU=",
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/sc-errors/-/sc-errors-1.4.1.tgz",
+          "integrity": "sha512-dBn92iIonpChTxYLgKkIT/PCApvmYT6EPIbRvbQKTgY6tbEbIy8XVUv4pGyKwEK4nCmvX4TKXcN0iXC6tNW6rQ==",
           "dev": true
         }
       }
@@ -34533,12 +35104,6 @@
       "requires": {
         "sc-emitter": "1.x.x"
       }
-    },
-    "sc-domain": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sc-domain/-/sc-domain-1.0.1.tgz",
-      "integrity": "sha1-qkAlCbh5unYBLpcy3B0H9lO4NLw=",
-      "dev": true
     },
     "sc-emitter": {
       "version": "1.0.1",
@@ -34578,27 +35143,31 @@
       "integrity": "sha512-whZWw70Gp5ibXXMcz6+Tulmk8xkwWMs42gG70p12hGscdUg8BICBvihS3pX2T3dWTw+yeZuGKiULr3MwL37SOQ==",
       "dev": true
     },
-    "sc-jsonwebtoken": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/sc-jsonwebtoken/-/sc-jsonwebtoken-7.4.2.tgz",
-      "integrity": "sha1-Kp9n2JHlroNCIQhSC4NoroM2x0k=",
+    "sc-simple-broker": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/sc-simple-broker/-/sc-simple-broker-2.1.3.tgz",
+      "integrity": "sha512-ldt0ybOS5fVZSMea5Z8qVu7lmDBTy0qO9BD6TseJjRuPx+g+stfSqmPAb0RsCsQUXRH8A1koCbwsuUnI9BOxvw==",
       "dev": true,
       "requires": {
-        "joi": "^6.10.1",
-        "jws": "^3.1.4",
-        "lodash.once": "^4.0.0",
-        "ms": "^2.0.0",
-        "xtend": "^4.0.1"
+        "sc-channel": "^1.2.0"
+      },
+      "dependencies": {
+        "sc-channel": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/sc-channel/-/sc-channel-1.2.0.tgz",
+          "integrity": "sha512-M3gdq8PlKg0zWJSisWqAsMmTVxYRTpVRqw4CWAdKBgAfVKumFcTjoCV0hYu7lgUXccCtCD8Wk9VkkE+IXCxmZA==",
+          "dev": true,
+          "requires": {
+            "component-emitter": "1.2.1"
+          }
+        }
       }
     },
-    "sc-simple-broker": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sc-simple-broker/-/sc-simple-broker-2.0.0.tgz",
-      "integrity": "sha1-Leb9NSNaC3bXrmNJ0cf53R4YCRw=",
-      "dev": true,
-      "requires": {
-        "sc-channel": "~1.0.6"
-      }
+    "sc-uws": {
+      "version": "10.148.2",
+      "resolved": "https://registry.npmjs.org/sc-uws/-/sc-uws-10.148.2.tgz",
+      "integrity": "sha512-wGXiwsORev5O3OOewsAYi1WVyMeNFMQ4bw/Qg/6g0C0J9vsEs8xnxf19hovAAQrOq6sMVrcxCNa2k1rBiDsDzw==",
+      "dev": true
     },
     "sc-ws": {
       "version": "1.0.2",
@@ -35014,81 +35583,88 @@
       }
     },
     "socketcluster": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/socketcluster/-/socketcluster-5.16.0.tgz",
-      "integrity": "sha1-4iihr0c8HKx8MI5e7qEWEGFvdL4=",
+      "version": "14.3.3",
+      "resolved": "https://registry.npmjs.org/socketcluster/-/socketcluster-14.3.3.tgz",
+      "integrity": "sha512-ISfwM0Sbwf968diYe4fWVTbwuWZSqoZsczN0s2veyAra3xj+43IDoJOy6pmQepagp8EsK+qAlZuN6GIIFieUbA==",
       "dev": true,
       "requires": {
-        "async": "2.0.0",
-        "base64id": "0.1.0",
-        "fs-extra": "2.0.0",
-        "inquirer": "1.1.3",
-        "minimist": "1.1.0",
-        "sc-auth": "~4.1.0",
-        "sc-broker-cluster": "~4.0.0",
-        "sc-domain": "~1.0.1",
-        "sc-emitter": "~1.1.0",
-        "sc-errors": "~1.3.0",
-        "socketcluster-server": "~5.15.0",
-        "uid-number": "0.0.5",
-        "uuid": "3.0.1"
+        "async": "2.3.0",
+        "fs-extra": "6.0.1",
+        "inquirer": "5.2.0",
+        "minimist": "1.2.0",
+        "sc-auth": "^5.0.2",
+        "sc-broker-cluster": "^7.0.0",
+        "sc-errors": "^1.4.1",
+        "socketcluster-server": "^14.3.2",
+        "uid-number": "0.0.6",
+        "uuid": "3.2.1"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+        "ansi-escapes": {
+          "version": "3.1.0",
+          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+          "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "async": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.3.0.tgz",
+          "integrity": "sha1-EBPRBRBH3TIP4k5JTVxm7K9hR9k=",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.14.0"
+          }
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "figures": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/async/-/async-2.0.0.tgz",
-          "integrity": "sha1-0JAK04WvE4BFQKEJxCFm4657K50=",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
           "dev": true,
           "requires": {
-            "lodash": "^4.8.0"
+            "escape-string-regexp": "^1.0.5"
           }
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "component-emitter": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz",
-          "integrity": "sha1-zNETqGOI0GSC0D3j/H35hSa6jv4=",
-          "dev": true
         },
         "inquirer": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-1.1.3.tgz",
-          "integrity": "sha1-bNKpP3CfpQd5cx/SJixpgVXKsvo=",
+          "version": "5.2.0",
+          "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
+          "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
           "dev": true,
           "requires": {
-            "ansi-escapes": "^1.1.0",
-            "chalk": "^1.0.0",
-            "cli-cursor": "^1.0.1",
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
             "cli-width": "^2.0.0",
-            "external-editor": "^1.0.1",
-            "figures": "^1.3.5",
+            "external-editor": "^2.1.0",
+            "figures": "^2.0.0",
             "lodash": "^4.3.0",
-            "mute-stream": "0.0.6",
-            "pinkie-promise": "^2.0.0",
+            "mute-stream": "0.0.7",
             "run-async": "^2.2.0",
-            "rx": "^4.1.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.0",
+            "rxjs": "^5.5.2",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
             "through": "^2.3.6"
           }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
         },
         "lodash": {
           "version": "4.17.11",
@@ -35097,16 +35673,35 @@
           "dev": true
         },
         "minimist": {
-          "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz",
-          "integrity": "sha1-zfIl6ImPhAolje1E/JF3Z3Cv3JM=",
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "mute-stream": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
-          "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s=",
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
           "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
         },
         "run-async": {
           "version": "2.3.0",
@@ -35117,31 +35712,35 @@
             "is-promise": "^2.1.0"
           }
         },
-        "sc-emitter": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/sc-emitter/-/sc-emitter-1.1.0.tgz",
-          "integrity": "sha1-7xGdQiL0xk+Ie0hpZO8REWzdDnU=",
+        "sc-errors": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/sc-errors/-/sc-errors-1.4.1.tgz",
+          "integrity": "sha512-dBn92iIonpChTxYLgKkIT/PCApvmYT6EPIbRvbQKTgY6tbEbIy8XVUv4pGyKwEK4nCmvX4TKXcN0iXC6tNW6rQ==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "component-emitter": "1.2.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
-        "sc-errors": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/sc-errors/-/sc-errors-1.3.3.tgz",
-          "integrity": "sha1-wAvEx2apcMyNWTfQjNWOkx19rgU=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
         },
         "uuid": {
-          "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
           "dev": true
         }
       }
@@ -35162,39 +35761,32 @@
       }
     },
     "socketcluster-server": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/socketcluster-server/-/socketcluster-server-5.15.0.tgz",
-      "integrity": "sha1-FCAl/mh9meeGMXpdtf1jmLufD7E=",
+      "version": "14.3.2",
+      "resolved": "https://registry.npmjs.org/socketcluster-server/-/socketcluster-server-14.3.2.tgz",
+      "integrity": "sha512-mUSCsRs4FCf4KMVZMzILUBrCwQe1PCD/tdVchtZlT5LDUcFH1CBaOy76HTbGcEHIBd5TvVilBgl5ke5m3wZgsg==",
       "dev": true,
       "requires": {
-        "async": "2.0.0",
-        "base64id": "0.1.0",
+        "async": "2.3.0",
+        "base64id": "1.0.0",
+        "component-emitter": "1.2.1",
         "lodash.clonedeep": "4.5.0",
-        "sc-auth": "~4.1.0",
-        "sc-domain": "~1.0.1",
-        "sc-emitter": "~1.1.0",
-        "sc-errors": "~1.3.0",
-        "sc-formatter": "~3.0.0",
-        "sc-simple-broker": "~2.0.0",
-        "uuid": "3.0.1",
-        "uws": "8.14.0",
-        "ws": "3.0.0"
+        "sc-auth": "^5.0.2",
+        "sc-errors": "^1.4.1",
+        "sc-formatter": "^3.0.2",
+        "sc-simple-broker": "^2.1.3",
+        "sc-uws": "^10.148.2",
+        "uuid": "3.2.1",
+        "ws": "5.1.1"
       },
       "dependencies": {
         "async": {
-          "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/async/-/async-2.0.0.tgz",
-          "integrity": "sha1-0JAK04WvE4BFQKEJxCFm4657K50=",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.3.0.tgz",
+          "integrity": "sha1-EBPRBRBH3TIP4k5JTVxm7K9hR9k=",
           "dev": true,
           "requires": {
-            "lodash": "^4.8.0"
+            "lodash": "^4.14.0"
           }
-        },
-        "component-emitter": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz",
-          "integrity": "sha1-zNETqGOI0GSC0D3j/H35hSa6jv4=",
-          "dev": true
         },
         "lodash": {
           "version": "4.17.11",
@@ -35202,19 +35794,10 @@
           "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
           "dev": true
         },
-        "sc-emitter": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/sc-emitter/-/sc-emitter-1.1.0.tgz",
-          "integrity": "sha1-7xGdQiL0xk+Ie0hpZO8REWzdDnU=",
-          "dev": true,
-          "requires": {
-            "component-emitter": "1.2.0"
-          }
-        },
         "sc-errors": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/sc-errors/-/sc-errors-1.3.3.tgz",
-          "integrity": "sha1-wAvEx2apcMyNWTfQjNWOkx19rgU=",
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/sc-errors/-/sc-errors-1.4.1.tgz",
+          "integrity": "sha512-dBn92iIonpChTxYLgKkIT/PCApvmYT6EPIbRvbQKTgY6tbEbIy8XVUv4pGyKwEK4nCmvX4TKXcN0iXC6tNW6rQ==",
           "dev": true
         },
         "sc-formatter": {
@@ -35224,9 +35807,9 @@
           "dev": true
         },
         "uuid": {
-          "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
           "dev": true
         }
       }
@@ -35328,16 +35911,6 @@
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
-    },
-    "spawn-sync": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
-      "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
-      "dev": true,
-      "requires": {
-        "concat-stream": "^1.4.7",
-        "os-shim": "^0.1.2"
-      }
     },
     "spdx-correct": {
       "version": "3.0.2",
@@ -35478,6 +36051,25 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "sqlite3": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-4.0.4.tgz",
+      "integrity": "sha512-CO8vZMyUXBPC+E3iXOCc7Tz2pAdq5BWfLcQmOokCOZW5S5sZ/paijiPOCdvzpdP83RroWHYa5xYlVqCxSqpnQg==",
+      "dev": true,
+      "requires": {
+        "nan": "~2.10.0",
+        "node-pre-gyp": "^0.10.3",
+        "request": "^2.87.0"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.10.0",
+          "resolved": "http://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+          "dev": true
+        }
+      }
     },
     "sshpk": {
       "version": "1.15.2",
@@ -35808,6 +36400,35 @@
       "integrity": "sha512-IlqtmLVaZA2qab8epUXbVWRn3aB1imbDMJtjB3nu4X0NqPkcY/JH9ZtCBWKHWPxs8Svi9tyo8w2dBoi07qZbBA==",
       "dev": true
     },
+    "tar": {
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+      "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+      "dev": true,
+      "requires": {
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.3.4",
+        "minizlib": "^1.1.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.2"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true
+        }
+      }
+    },
+    "tarn": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/tarn/-/tarn-1.1.4.tgz",
+      "integrity": "sha512-j4samMCQCP5+6Il9/cxCqBd3x4vvlLeVdoyGex0KixPKl4F8LpNbDSC6NDhjianZgUngElRr9UI1ryZqJDhwGg==",
+      "dev": true
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -35873,6 +36494,15 @@
       "integrity": "sha512-YwT8pjmNcAXBZqrubu22P4FYsh2D4dxRmnWBOL8Jk8bUcRUtc5326kx32tuTmFDAZtLOGEVNl8POAR8j896Iow==",
       "dev": true
     },
+    "tildify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
+      "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0"
+      }
+    },
     "timers-browserify": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
@@ -35883,12 +36513,12 @@
       }
     },
     "tmp": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
-      "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "~1.0.1"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "to-arraybuffer": {
@@ -35943,15 +36573,6 @@
       "requires": {
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
-      }
-    },
-    "topo": {
-      "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
-      "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.x.x"
       }
     },
     "tough-cookie": {
@@ -36132,9 +36753,9 @@
       }
     },
     "uid-number": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
-      "integrity": "sha1-Wj2yPvXb1VuB/ODsmirG/M3ruB4=",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+      "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
       "dev": true
     },
     "ultron": {
@@ -36252,6 +36873,12 @@
       "requires": {
         "imurmurhash": "^0.1.4"
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",
@@ -36441,12 +37068,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-    },
-    "uws": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/uws/-/uws-8.14.0.tgz",
-      "integrity": "sha1-rMFIjRPssj/i+UKn6vsGaB+pFDE=",
-      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.0.2",
@@ -36800,6 +37421,15 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -36840,27 +37470,12 @@
       }
     },
     "ws": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-3.0.0.tgz",
-      "integrity": "sha1-mN2wAFbIOQy3Ued4h4hJf5kQO2w=",
+      "version": "5.1.1",
+      "resolved": "http://registry.npmjs.org/ws/-/ws-5.1.1.tgz",
+      "integrity": "sha512-bOusvpCb09TOBLbpMKszd45WKC2KPtxiyiHanv+H2DE3Az+1db5a/L7sVJZVDPUC1Br8f0SKRr1KjLpD1U/IAw==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.0.1",
-        "ultron": "~1.1.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
-          "dev": true
-        },
-        "ultron": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-          "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
-          "dev": true
-        }
+        "async-limiter": "~1.0.0"
       }
     },
     "xml-name-validator": {
@@ -36996,6 +37611,21 @@
       "dev": true,
       "requires": {
         "camelcase": "^4.1.0"
+      }
+    },
+    "zen-observable": {
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.11.tgz",
+      "integrity": "sha512-N3xXQVr4L61rZvGMpWe8XoCGX8vhU35dPyQ4fm5CY/KDlG0F75un14hjbckPXTDuKUY6V0dqR2giT6xN8Y4GEQ==",
+      "dev": true
+    },
+    "zen-observable-ts": {
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.11.tgz",
+      "integrity": "sha512-8bs7rgGV4kz5iTb9isudkuQjtWwPnQ8lXq6/T76vrepYZVMsDEv6BXaEA+DHdJSK3KVLduagi9jSpSAJ5NgKHw==",
+      "dev": true,
+      "requires": {
+        "zen-observable": "^0.8.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "react-addons-test-utils": "^15.1.0",
     "redux-mock-store": "^1.1.0",
     "remote-redux-devtools": "^0.3.3",
-    "remotedev-server": "^0.1.2",
+    "remotedev-server": "^0.3.1",
     "rimraf": "^2.5.3",
     "script-loader": "^0.7.2",
     "semver": "^5.1.0",


### PR DESCRIPTION
Fixes an issue preventing redux devtools from loading successfully, simply by bumping to a more recent version.