### PR TITLE
Replace deprecated prop-types imports

### DIFF
--- a/src/child/components/SearchResult.js
+++ b/src/child/components/SearchResult.js
@@ -1,9 +1,10 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import * as PropTypes from 'prop-types';
 import classNames from 'classnames';
+
 import { truncate } from '../services/formatters';
 
 const Stock = ({ isFavourite, stock, selected, bindings }) => {
-
     const cls = classNames({
         'search-result': true,
         darkens: true,

--- a/src/child/components/favourite/Favourite.js
+++ b/src/child/components/favourite/Favourite.js
@@ -1,5 +1,7 @@
-import React, { Component, PropTypes } from 'react';
+import React from 'react';
+import * as PropTypes from 'prop-types';
 import classNames from 'classnames';
+
 import { truncate } from '../../services/formatters';
 import Minichart from '../minichart/Minichart';
 import Confirmation from './UnfavouriteConfirmation';
@@ -15,7 +17,7 @@ const bubbleHeadFlippedOffset = -10;
 const modalOffset = 30;
 const modalFlippedOffset = -89;
 
-class Favourite extends Component {
+class Favourite extends React.Component {
 
     constructor(props) {
         super(props);
@@ -33,7 +35,7 @@ class Favourite extends Component {
     }
 
     componentDidMount() {
-        const stockCode = this.props.stockCode;
+        const { bindings, stockCode } = this.props;
         quandlServiceGetStockData(stockCode)
             .then((response) => {
                 const data = response.stockData.data[0];
@@ -50,7 +52,7 @@ class Favourite extends Component {
                     stockData = { name: stockName };
                 }
                 const chartData = response;
-                this.props.bindings.onQuandlResponse(stockCode, stockName);
+                bindings.onQuandlResponse(stockCode, stockName);
                 this.setState({ stockData, chartData });
             });
     }

--- a/src/child/components/favourite/UnfavouriteConfirmation.js
+++ b/src/child/components/favourite/UnfavouriteConfirmation.js
@@ -1,15 +1,16 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import * as PropTypes from 'prop-types';
 
-const UnfavouriteConfirmation = (props) => (
-    <div className="confirmation-backdrop" onClick={props.bindings.onModalBackdropClick}>
-        <div className="bubble-head" style={{ top: props.bindings.modalBubbleHeadTopPosition() }} />
-        <div className={`confirmation-modal${props.isFlipped ? ' flipped' : ''}`} style={{ top: props.bindings.modalTopPosition() }}>
+const UnfavouriteConfirmation = ({ bindings, isFlipped }) => (
+    <div className="confirmation-backdrop" onClick={bindings.onModalBackdropClick}>
+        <div className="bubble-head" style={{ top: bindings.modalBubbleHeadTopPosition() }} />
+        <div className={`confirmation-modal${isFlipped ? ' flipped' : ''}`} style={{ top: bindings.modalTopPosition() }}>
             <div className="confirmation-content" onClick={(e) => e.stopPropagation()}>
                 <div className="message">
                     <span>Are you sure you wish to remove this stock from your favourites?</span>
                 </div>
                 <div className="buttons">
-                    <button className="btn btn-primary" onClick={props.bindings.onModalConfirmClick}>Confirm</button>
+                    <button className="btn btn-primary" onClick={bindings.onModalConfirmClick}>Confirm</button>
                 </div>
             </div>
         </div>

--- a/src/child/components/minichart/Minichart.js
+++ b/src/child/components/minichart/Minichart.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React from 'react';
+import * as PropTypes from 'prop-types';
 import { scaleLinear, scaleTime } from 'd3-scale';
 import { select } from 'd3-selection';
 import {
@@ -21,7 +22,7 @@ function innerDimensions(element) {
     };
 }
 
-class Minichart extends Component {
+class Minichart extends React.Component {
 
     shouldComponentUpdate(nextProps) {
         return this.props.chartData !== nextProps.chartData;

--- a/src/child/containers/App.js
+++ b/src/child/containers/App.js
@@ -1,5 +1,7 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
+import * as PropTypes from 'prop-types';
+
 import Toolbar from './toolbar/Toolbar';
 import SideBar from './sidebars/Sidebar';
 import Showcase from './showcase/Showcase';

--- a/src/child/containers/sidebars/Sidebar.js
+++ b/src/child/containers/sidebars/Sidebar.js
@@ -1,22 +1,22 @@
-import React, { Component, PropTypes } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
+import * as PropTypes from 'prop-types';
 import classNames from 'classnames';
+
 import Favourites from './favourites/Favourites';
 import ClosedWindows from './closedWindows/ClosedWindows';
 import Search from './search/Search';
 import { sidebarSelector as mapStateToProps } from '../../selectors/selectors';
 import currentWindowService from '../../services/currentWindowService';
-
 import { openClosedWindow } from '../../../parent/actions/parent';
 import { selectFavourites, selectSearch } from '../../actions/sidebar';
 import { selectStock } from '../../actions/selection';
 import { toggleFavourite, moveFavouriteFromWindow } from '../../actions/favourites';
-
 import windowStateShape from '../../propTypeShapes/windowState';
 import favouritesShape from '../../propTypeShapes/favourites';
 import sidebarShape from '../../propTypeShapes/sidebar';
 
-class Sidebar extends Component {
+class Sidebar extends React.Component {
     constructor(props) {
         super(props);
         this.onDragEnter = this.onDragEnter.bind(this);

--- a/src/child/containers/sidebars/closedWindows/ClosedWindows.js
+++ b/src/child/containers/sidebars/closedWindows/ClosedWindows.js
@@ -1,12 +1,13 @@
-import React, { Component, PropTypes } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
+import * as PropTypes from 'prop-types';
 import moment from 'moment';
-import { closedWindowsSelector as mapStateToProps } from '../../../selectors/selectors';
 
+import { closedWindowsSelector as mapStateToProps } from '../../../selectors/selectors';
 import closedWindowsImageInactive from '../../../assets/png/closed_tabs.png';
 import closedWindowsImageActive from '../../../assets/png/closed_tabs_active.png';
 
-class ClosedWindows extends Component {
+class ClosedWindows extends React.Component {
 
     constructor(props) {
         super(props);

--- a/src/child/containers/sidebars/favourites/Favourites.js
+++ b/src/child/containers/sidebars/favourites/Favourites.js
@@ -1,6 +1,7 @@
 /* global $ */
-import React, { Component, PropTypes } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
+import * as PropTypes from 'prop-types';
 import { quandlResponse, insertFavouriteAt } from '../../../actions/favourites';
 import { selectStock } from '../../../actions/selection';
 import { resizeToPrevious } from '../../../actions/window';
@@ -13,7 +14,7 @@ import selectionShape from '../../../propTypeShapes/selection';
 import favouritesShape from '../../../propTypeShapes/favourites';
 import windowStateShape from '../../../propTypeShapes/windowState';
 
-class Favourites extends Component {
+class Favourites extends React.Component {
     constructor(props) {
         super(props);
 

--- a/src/child/containers/sidebars/search/Search.js
+++ b/src/child/containers/sidebars/search/Search.js
@@ -1,6 +1,7 @@
 /* global $ */
-import React, { Component, PropTypes } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
+import * as PropTypes from 'prop-types';
 import { searchInput, search } from '../../../actions/search';
 import { selectFavourites } from '../../../actions/sidebar';
 import searchTabImage from '../../../assets/png/search_tab.png';
@@ -12,7 +13,7 @@ import selectionShape from '../../../propTypeShapes/selection';
 
 const SEARCH_TIMEOUT_INTERVAL = 250;
 
-class Search extends Component {
+class Search extends React.Component {
     constructor(props) {
         super(props);
         this.onChange = this.onChange.bind(this);
@@ -56,7 +57,7 @@ class Search extends Component {
 
     render() {
         const { favourites, isSearching, hasErrors, results, term, selection } = this.props;
-        const codes = favourites.codes;
+        const { codes, names } = favourites;
         const bindings = {
             onClick: this.onClick,
             onIconClick: this.onIconClick
@@ -79,17 +80,17 @@ class Search extends Component {
 
                         {isSearching && <div className="loading-message results-message">Loading search results...</div>}
 
-                        {!isSearching && !results && favourites.codes.map((stockCode) =>
+                        {!isSearching && !results && codes.map((stockCode) =>
                             <SearchResult
                               key={stockCode}
-                              stock={{ code: stockCode, name: favourites.names[stockCode] }}
+                              stock={{ code: stockCode, name: names[stockCode] }}
                               bindings={bindings}
                               selected={stockCode === selection.code}
-                              isFavourite={favourites.codes.indexOf(stockCode) >= 0}
+                              isFavourite={codes.indexOf(stockCode) >= 0}
                             />)
                         }
 
-                        {!isSearching && !results && !hasErrors && favourites.codes.length === 0 &&
+                        {!isSearching && !results && !hasErrors && codes.length === 0 &&
                             <div className="no-favourites">
                                 <p>Use the search tab to add new stocks to the list.</p>
                             </div>

--- a/src/child/containers/toolbar/Toolbar.js
+++ b/src/child/containers/toolbar/Toolbar.js
@@ -1,5 +1,7 @@
-import React, { Component, PropTypes } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
+import * as PropTypes from 'prop-types';
+
 import {
     minimizeWindow,
     maximizeWindow,
@@ -9,11 +11,11 @@ import {
 } from '../../actions/window';
 import { toolbarSelector as mapStateToProps } from '../../selectors/selectors';
 import { undockWindow } from '../../services/LayoutsService';
-import icon from '../../assets/png/scottlogic_logo.png';
-
 import windowStateShape from '../../propTypeShapes/windowState';
 
-class Toolbar extends Component {
+import icon from '../../assets/png/scottlogic_logo.png';
+
+class Toolbar extends React.Component {
     constructor(props) {
         super(props);
         this.onMinimizeClick = this.onMinimizeClick.bind(this);

--- a/src/child/propTypeShapes/favourites.js
+++ b/src/child/propTypeShapes/favourites.js
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import * as PropTypes from 'prop-types';
 
 const favouritesShape = PropTypes.shape({
     codes: PropTypes.array.isRequired,

--- a/src/child/propTypeShapes/selection.js
+++ b/src/child/propTypeShapes/selection.js
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import * as PropTypes from 'prop-types';
 
 const selectionShape = PropTypes.shape({
     code: PropTypes.string,

--- a/src/child/propTypeShapes/sidebar.js
+++ b/src/child/propTypeShapes/sidebar.js
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import * as PropTypes from 'prop-types';
 
 const sidebarShape = PropTypes.shape({
     showFavourites: PropTypes.bool,

--- a/src/child/propTypeShapes/windowState.js
+++ b/src/child/propTypeShapes/windowState.js
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import * as PropTypes from 'prop-types';
 
 const windowStateShape = PropTypes.shape({
     isCompact: PropTypes.bool.isRequired,


### PR DESCRIPTION
Updating the code to use the standalone prop-types package (which was added to package.json in a previous PR).

Plus some minor code cleanup, related to accessing props.