### PR TITLE
Remove event handler when child window closed

### DIFF
--- a/src/parent/reducers/reducers.js
+++ b/src/parent/reducers/reducers.js
@@ -35,9 +35,6 @@ const rootReducer = reduceReducers(
         }
 
         case ACTION_TYPES.CLOSE: {
-            // FIXME Solve why close event is fired twice when re-opened window is closed! Event listener not removed?
-            if (!state.childWindows[action.windowName]) return state;
-
             const newClosedWindows = { ...state.closedWindows };
             const closingWindowHasFavourites = state.childWindows[action.windowName].favourites.codes.length > 0;
 
@@ -47,6 +44,7 @@ const rootReducer = reduceReducers(
                     date: action.date
                 };
             }
+
             if (Object.keys(newClosedWindows).length > MAX_CLOSED_WINDOWS) {
                 Object.entries(newClosedWindows) // [[winName1, winObject1], [winName2, winObject2], ...]
                     .sort((aEntry, bEntry) => bEntry[1].date - aEntry[1].date)


### PR DESCRIPTION
Store mapping of child windows by name, so that we can remove the `closed` event listener when a child window is closed.

fixes #1006 