### PR TITLE
Close the chart container when the last chart window is closed

### DIFF
--- a/stockflux-chart-container/src/App.js
+++ b/stockflux-chart-container/src/App.js
@@ -3,11 +3,12 @@ import * as fdc3 from 'openfin-fdc3';
 import {InterApplicationBusHooks} from 'openfin-react-hooks';
 
 let latestListener;
+let currentListener;
+let windows = [];
 
 function App() {
   const [content, setContent] = useState(undefined);
-  const [windows, setWindows] = useState([]);
-
+  
   const createWindow = async (context, windowName) => {
     const winOption = {
         name: windowName,
@@ -27,23 +28,32 @@ function App() {
     return await window.fin.Window.create(winOption);
   }
 
-  const currentListener = fdc3.addIntentListener("ViewChart", context => {
+  const handler = (context) => {
     if (context && currentListener === latestListener) {
       const windowName = 'container-' + context.name;
-      createWindow(context, windowName).then(chartWindow => {
-        setWindows([...windows, windowName]);
-        setContent({
-          symbol: context.name,
-          name: context.id.default
+      if (!windows.find(window => window === windowName)) {
+        createWindow(context, windowName).then(chartWindow => {
+          windows = [...windows, windowName];
+          setContent({
+            symbol: context.name,
+            name: context.id.default
+          });
+          chartWindow.addListener("closed", () => {
+            if (wasFinalChartWindow(windowName)) {
+              window.fin.Window.getCurrentSync().close(true);
+            }
+          })
         });
-        chartWindow.addListener("closed", () => {
-          let newWindows = [...windows];
-          newWindows.splice(newWindows.indexOf(windowName));
-          setWindows(newWindows);
-        })
-      });
+      }
     }
-  });
+  }
+  
+  const wasFinalChartWindow = (windowName) => {
+    windows = windows.filter(name => name !== windowName);
+    return windows.length === 0 ? true : false;
+  }
+
+  currentListener = fdc3.addIntentListener("ViewChart", context => handler(context));
 
   latestListener = currentListener;
 

--- a/stockflux-chart-container/src/App.js
+++ b/stockflux-chart-container/src/App.js
@@ -39,8 +39,8 @@ function App() {
             name: context.id.default
           });
           chartWindow.addListener("closed", () => {
-            if (wasFinalChartWindow(windowName)) {
-              window.fin.Window.getCurrentSync().close(true);
+            if (removeWindow(windowName)) {
+              closeParentContainer();
             }
           })
         });
@@ -48,9 +48,13 @@ function App() {
     }
   }
   
-  const wasFinalChartWindow = (windowName) => {
+  const removeWindow = (windowName) => {
     windows = windows.filter(name => name !== windowName);
-    return windows.length === 0 ? true : false;
+    return windows.length === 0;
+  }
+  
+  const closeParentContainer = () => {
+    window.fin.Window.getCurrentSync().close(true);
   }
 
   currentListener = fdc3.addIntentListener("ViewChart", context => handler(context));


### PR DESCRIPTION
This will prevent instances of the chart container sitting idle as the user is unable to close the container manually