### PR TITLE
Close search results window when an intent is fired

### DIFF
--- a/stockflux-launcher/src/free-text-search/FreeTextSearch.js
+++ b/stockflux-launcher/src/free-text-search/FreeTextSearch.js
@@ -128,16 +128,16 @@ const FreeTextSearch = ({ dockedTo }) => {
       switch (message.type) {
         case 'news-view':
           Intents.viewNews(message.code);
-          break;
         case 'watchlist-add':
           Intents.addWatchlist(message.code, message.name);
-          break;
         case 'chart-add':
           Intents.viewChart(message.code, message.name);
-          break;
         default:
           break;
       }
+      closeResultsWindow();
+      searchInputRef.current.value = '';
+      searchInputRef.current.blur();
     });
   }, []);
 

--- a/stockflux-launcher/src/free-text-search/FreeTextSearch.js
+++ b/stockflux-launcher/src/free-text-search/FreeTextSearch.js
@@ -123,21 +123,30 @@ const FreeTextSearch = ({ dockedTo }) => {
       .then(options => setParentUuid(options.uuid));
   }, []);
 
+  const closeAndClearSearch = () => {
+    closeResultsWindow();
+    searchInputRef.current.value = '';
+    searchInputRef.current.blur();
+  }
+
   useEffect(() => {
     window.fin.InterApplicationBus.subscribe({ uuid: window.fin.Window.me.uuid }, 'intent-request', (message) => {
       switch (message.type) {
         case 'news-view':
           Intents.viewNews(message.code);
+          closeAndClearSearch();
+          break;
         case 'watchlist-add':
           Intents.addWatchlist(message.code, message.name);
+          closeAndClearSearch();
+          break;
         case 'chart-add':
           Intents.viewChart(message.code, message.name);
+          closeAndClearSearch();
+          break;
         default:
           break;
       }
-      closeResultsWindow();
-      searchInputRef.current.value = '';
-      searchInputRef.current.blur();
     });
   }, []);
 


### PR DESCRIPTION
Close search results window when one of chart, news or watchlist is selected. 
Search query is cleared and the input is unfocused.