### PR TITLE
Create edit button on grid to open edit form

### DIFF
--- a/stockflux-securities-master/src/App.js
+++ b/stockflux-securities-master/src/App.js
@@ -9,8 +9,6 @@ import "./App.css";
 
 const App = () => {
 
-  //hard coded prop to be replaced with securities object to be edited
-
   return (
     <div>
       <Components.Titlebar />

--- a/stockflux-securities-master/src/App.js
+++ b/stockflux-securities-master/src/App.js
@@ -15,7 +15,7 @@ const App = () => {
       <Switch>
         <Route exact path="/" component={SecuritiesTable} />
         <Route exact path="/inputform/:securityId" component={InputForm} />
-        <Route exact path="/inputform/" component={InputForm} />
+        <Route exact path="/inputform" component={InputForm} />
         <Redirect to="/" />
       </Switch>
     </div>

--- a/stockflux-securities-master/src/App.js
+++ b/stockflux-securities-master/src/App.js
@@ -8,11 +8,22 @@ import { Redirect, Route, Switch } from "react-router-dom";
 import "./App.css";
 
 const App = () => {
+
+  //hard coded prop to be replaced with securities object to be edited
+  const props = {
+    securityId: "FOO:BAR"
+  };
+
   return (
     <div>
       <Components.Titlebar />
       <Switch>
         <Route exact path="/" component={SecuritiesTable} />
+        <Route
+          exact
+          path="/inputform/edit"
+          render={routeProps => <InputForm {...routeProps} {...props} />}
+        />
         <Route exact path="/inputform" component={InputForm} />
         <Redirect to="/" />
       </Switch>

--- a/stockflux-securities-master/src/App.js
+++ b/stockflux-securities-master/src/App.js
@@ -14,7 +14,7 @@ const App = () => {
       <Components.Titlebar />
       <Switch>
         <Route exact path="/" component={SecuritiesTable} />
-        <Route path="/inputform/:securityId" component={InputForm} />
+        <Route exact path="/inputform/:securityId" component={InputForm} />
         <Route exact path="/inputform/" component={InputForm} />
         <Redirect to="/" />
       </Switch>

--- a/stockflux-securities-master/src/App.js
+++ b/stockflux-securities-master/src/App.js
@@ -10,21 +10,14 @@ import "./App.css";
 const App = () => {
 
   //hard coded prop to be replaced with securities object to be edited
-  const props = {
-    securityId: "FOO:BAR"
-  };
 
   return (
     <div>
       <Components.Titlebar />
       <Switch>
         <Route exact path="/" component={SecuritiesTable} />
-        <Route
-          exact
-          path="/inputform/edit"
-          render={routeProps => <InputForm {...routeProps} {...props} />}
-        />
-        <Route exact path="/inputform" component={InputForm} />
+        <Route path="/inputform/:securityId" component={InputForm} />
+        <Route exact path="/inputform/" component={InputForm} />
         <Redirect to="/" />
       </Switch>
     </div>

--- a/stockflux-securities-master/src/components/AddSecurityButton.css
+++ b/stockflux-securities-master/src/components/AddSecurityButton.css
@@ -1,0 +1,12 @@
+.add-security-button > button {
+    border: solid 1px var(--text-teal);
+    background: none;
+    font-family: var(--font-roboto-sans-serif);
+    color: var(--text-teal-light);
+    font-weight: var(--font-weight-bolder);
+    border-radius: 25px;
+    height: 50px;
+    width: 250px;
+    font-size: var(--font-xxxlarge);
+    text-align: center;
+  }

--- a/stockflux-securities-master/src/components/AddSecurityButton.css
+++ b/stockflux-securities-master/src/components/AddSecurityButton.css
@@ -1,16 +1,27 @@
-.add-security-button > button {
+.add-security-button-small > button,
+.add-security-button-large > button {
     border: solid 1px var(--text-teal);
     background: none;
     font-family: var(--font-roboto-sans-serif);
     color: var(--text-teal-light);
     font-weight: var(--font-weight-bolder);
     border-radius: 25px;
-    height: 50px;
-    width: 250px;
-    font-size: var(--font-xxxlarge);
     text-align: center;
 }
 
-.add-security-button > button:hover {
+.add-security-button-small > button:hover,
+.add-security-button-large > button:hover {
   color: var(--text-teal);
+}
+
+.add-security-button-small > button {
+  height: 30px;
+  width: 180px;
+  font-size: var(--font-xlarge);
+}
+
+.add-security-button-large > button {
+  height: 50px;
+  width: 250px;
+  font-size: var(--font-xxxlarge);
 }

--- a/stockflux-securities-master/src/components/AddSecurityButton.css
+++ b/stockflux-securities-master/src/components/AddSecurityButton.css
@@ -9,8 +9,8 @@
     width: 250px;
     font-size: var(--font-xxxlarge);
     text-align: center;
-  }
+}
 
 .add-security-button > button:hover {
   color: var(--text-teal);
-  }
+}

--- a/stockflux-securities-master/src/components/AddSecurityButton.css
+++ b/stockflux-securities-master/src/components/AddSecurityButton.css
@@ -10,3 +10,7 @@
     font-size: var(--font-xxxlarge);
     text-align: center;
   }
+
+.add-security-button > button:hover {
+  color: var(--text-teal);
+  }

--- a/stockflux-securities-master/src/components/AddSecurityButton.js
+++ b/stockflux-securities-master/src/components/AddSecurityButton.js
@@ -1,0 +1,15 @@
+import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import "./AddSecurityButton.css";
+
+const AddSecuritiesButton = () => {
+  return (
+    <Link to="/inputform">
+      <div className="add-security-button">
+        <button>Click to add security</button>
+      </div>
+    </Link>
+  );
+};
+
+export default AddSecuritiesButton;

--- a/stockflux-securities-master/src/components/AddSecurityButton.js
+++ b/stockflux-securities-master/src/components/AddSecurityButton.js
@@ -1,10 +1,10 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { Link } from "react-router-dom";
 import "./AddSecurityButton.css";
 
 const AddSecuritiesButton = () => {
   return (
-    <Link to="/inputform">
+    <Link to="/inputform/">
       <div className="add-security-button">
         <button>Click to add security</button>
       </div>

--- a/stockflux-securities-master/src/components/AddSecurityButton.js
+++ b/stockflux-securities-master/src/components/AddSecurityButton.js
@@ -2,7 +2,7 @@ import React from "react";
 import { Link } from "react-router-dom";
 import "./AddSecurityButton.css";
 
-const AddSecuritiesButton = ({size}) => {
+const AddSecuritiesButton = ({ size }) => {
   return (
     <Link to="/inputform">
       <div className={`add-security-button-${size}`}>

--- a/stockflux-securities-master/src/components/AddSecurityButton.js
+++ b/stockflux-securities-master/src/components/AddSecurityButton.js
@@ -2,11 +2,11 @@ import React from "react";
 import { Link } from "react-router-dom";
 import "./AddSecurityButton.css";
 
-const AddSecuritiesButton = () => {
+const AddSecuritiesButton = ({size}) => {
   return (
-    <Link to="/inputform/">
-      <div className="add-security-button">
-        <button>Click to add security</button>
+    <Link to="/inputform">
+      <div className={`add-security-button-${size}`}>
+        <button>Add a security</button>
       </div>
     </Link>
   );

--- a/stockflux-securities-master/src/components/ErrorDisplayer.css
+++ b/stockflux-securities-master/src/components/ErrorDisplayer.css
@@ -1,0 +1,4 @@
+.securities-error-message {
+    color: red;
+    font-size: var(--font-xxxlarge);
+  }

--- a/stockflux-securities-master/src/components/ErrorDisplayer.js
+++ b/stockflux-securities-master/src/components/ErrorDisplayer.js
@@ -1,0 +1,10 @@
+import React from "react";
+import "./ErrorDisplayer.css";
+
+const ErrorDisplayer = ({ errorMessage }) => {
+  return (
+    <div className="securities-error-message">{errorMessage}</div>
+  );
+};
+
+export default ErrorDisplayer;

--- a/stockflux-securities-master/src/components/ErrorMessage.css
+++ b/stockflux-securities-master/src/components/ErrorMessage.css
@@ -1,0 +1,4 @@
+.securities-error-message {
+    color: red;
+    font-size: var(--font-xxxlarge);
+  }

--- a/stockflux-securities-master/src/components/ErrorMessage.js
+++ b/stockflux-securities-master/src/components/ErrorMessage.js
@@ -1,0 +1,8 @@
+import React from "react";
+import "./ErrorMessage.css";
+
+const ErrorMessage = ({ errorMessage }) => {
+  return <div className="securities-error-message">{errorMessage}</div>;
+};
+
+export default ErrorMessage;

--- a/stockflux-securities-master/src/components/InputForm.js
+++ b/stockflux-securities-master/src/components/InputForm.js
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import "./InputForm.css";
 
-const InputForm = () => {
+const InputForm = ({ securityId }) => {
   const [name, setName] = useState("");
   const [exchange, setExchange] = useState("");
   const [symbol, setSymbol] = useState("");
@@ -30,7 +30,7 @@ const InputForm = () => {
 
   return (
     <div className="input-form-container">
-      <div className="input-form-title">Create a Security</div>
+      <div className="input-form-title">{securityId ? "Edit Security" : "Create a Security"}</div>
       <form className="input-form-body" onSubmit={submitForm}>
         <div className="input-row">
           <label className="input-label" htmlFor="name-input">

--- a/stockflux-securities-master/src/components/InputForm.js
+++ b/stockflux-securities-master/src/components/InputForm.js
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import "./InputForm.css";
 
-const InputForm = ({ securityId }) => {
+const InputForm = ({ match }) => {
   const [name, setName] = useState("");
   const [exchange, setExchange] = useState("");
   const [symbol, setSymbol] = useState("");
@@ -30,7 +30,7 @@ const InputForm = ({ securityId }) => {
 
   return (
     <div className="input-form-container">
-      <div className="input-form-title">{securityId ? "Edit Security" : "Create a Security"}</div>
+      <div className="input-form-title">{match.params.securityId ? "Edit Security" : "Create a Security"}</div>
       <form className="input-form-body" onSubmit={submitForm}>
         <div className="input-row">
           <label className="input-label" htmlFor="name-input">

--- a/stockflux-securities-master/src/components/SecuritiesTable.css
+++ b/stockflux-securities-master/src/components/SecuritiesTable.css
@@ -103,11 +103,6 @@
   outline: none;
 }
 
-.securities-error-message {
-  color: red;
-  font-size: var(--font-xxxlarge);
-}
-
 .securities-edit-button > button,
 .securities-delete-button > button {
   border: none;

--- a/stockflux-securities-master/src/components/SecuritiesTable.css
+++ b/stockflux-securities-master/src/components/SecuritiesTable.css
@@ -123,4 +123,3 @@
 .securities-row-options {
   display: flex;
 }
-

--- a/stockflux-securities-master/src/components/SecuritiesTable.css
+++ b/stockflux-securities-master/src/components/SecuritiesTable.css
@@ -22,7 +22,7 @@
 .header-container,
 .securities-table-row {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(4, 1fr);
 }
 
 .securities-table-row:last-child > div {
@@ -55,6 +55,7 @@
   padding-right: 0;
 }
 
+.securities-row-options,
 .securities-table-header,
 .securities-exchange-data,
 .securities-symbol-data,
@@ -97,15 +98,24 @@
   font-size: var(--font-xxxlarge);
   text-align: center;
 }
-
+.securities-edit-button > button:focus,
+.securities-delete-button > button:focus,
 .add-security-button > button:focus {
   outline: none;
-  color: var(--text-grey-darkest);
-  border-color: var(--text-grey-darkest);
 }
 
 .securities-error-message {
   color: red;
   font-size: var(--font-xxxlarge);
+}
+.securities-edit-button > button,
+.securities-delete-button > button {
+  border: none;
+  background: none;
+  color: var(--text-teal-light);
+}
+
+.securities-row-options {
+  display: flex;
 }
 

--- a/stockflux-securities-master/src/components/SecuritiesTable.css
+++ b/stockflux-securities-master/src/components/SecuritiesTable.css
@@ -8,11 +8,22 @@
   font-weight: var(--font-weight-normal);
 }
 
+.securities-title-container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--margin-medium);
+}
+
 .securities-title {
   padding: var(--padding-large) 0 var(--padding-large) var(--padding-medium);
   font-weight: var(--font-weight-bolder);
   margin-left: var(--padding-small);
   font-size: var(--font-xxxlarge);
+}
+
+.add-securities-button-above-table {
+  margin: var(--margin-small) var(--margin-medium) var(--margin-small) 0;
 }
 
 .header-container {
@@ -103,12 +114,12 @@
   color: var(--text-teal-light);
 }
 
+.securities-edit-button > button:hover,
+.securities-delete-button > button:hover {
+  color: var(--text-teal);
+}
+
 .securities-row-options {
   display: flex;
 }
 
-.add-security-button-container {
-  display: flex;
-  justify-content: center;
-  margin-top: var(--margin-medium);
-}

--- a/stockflux-securities-master/src/components/SecuritiesTable.css
+++ b/stockflux-securities-master/src/components/SecuritiesTable.css
@@ -86,18 +86,6 @@
   padding: var(--margin-medium) var(--margin-medium);
 }
 
-.add-security-button > button {
-  border: solid 1px var(--text-teal);
-  background: none;
-  font-family: var(--font-roboto-sans-serif);
-  color: var(--text-teal-light);
-  font-weight: var(--font-weight-bolder);
-  border-radius: 25px;
-  height: 50px;
-  width: 250px;
-  font-size: var(--font-xxxlarge);
-  text-align: center;
-}
 .securities-edit-button > button:focus,
 .securities-delete-button > button:focus,
 .add-security-button > button:focus {
@@ -119,3 +107,8 @@
   display: flex;
 }
 
+.add-security-button-container {
+  display: flex;
+  justify-content: center;
+  margin-top: var(--margin-medium);
+}

--- a/stockflux-securities-master/src/components/SecuritiesTable.css
+++ b/stockflux-securities-master/src/components/SecuritiesTable.css
@@ -107,6 +107,7 @@
   color: red;
   font-size: var(--font-xxxlarge);
 }
+
 .securities-edit-button > button,
 .securities-delete-button > button {
   border: none;

--- a/stockflux-securities-master/src/components/SecuritiesTable.js
+++ b/stockflux-securities-master/src/components/SecuritiesTable.js
@@ -3,6 +3,7 @@ import Components from "stockflux-components";
 import "./SecuritiesTable.css";
 import { Link } from "react-router-dom";
 import { getSecuritiesData } from "../services/SecuritiesService";
+import AddSecurityButton from "./AddSecurityButton";
 
 const SecuritiesTable = () => {
   const [securitiesData, setSecuritiesData] = useState([]);
@@ -45,8 +46,10 @@ const SecuritiesTable = () => {
           {errorMessage}
         </div>
         ) : (
-        <div className="table-body">
+        <div>>
           {securitiesData.length > 0 ? (
+            <>
+            <div className="table-body">
             <Components.ScrollWrapperY>
               {securitiesData.map((item, index) => (
                 <div key={index} className="securities-table-row">
@@ -62,14 +65,18 @@ const SecuritiesTable = () => {
                 </div>
               ))}
             </Components.ScrollWrapperY>
+            </div>
+            <div className="add-security-button-container"><AddSecurityButton /></div>
+            </>
           ) : (
+            <div className="table-body">
+
             <div className="no-securities-container">
               <div className="no-securities-message">
                 You have no securities to show
               </div>
-              <Link to="/inputform">
-                <div className="add-security-button"><button>Click to add security</button></div>
-              </Link>
+              <AddSecurityButton />
+            </div>
             </div>
           )}
         </div>

--- a/stockflux-securities-master/src/components/SecuritiesTable.js
+++ b/stockflux-securities-master/src/components/SecuritiesTable.js
@@ -4,7 +4,6 @@ import "./SecuritiesTable.css";
 import { Link } from "react-router-dom";
 import { getSecuritiesData } from "../services/SecuritiesService";
 
-
 const SecuritiesTable = () => {
   const [securitiesData, setSecuritiesData] = useState([]);
 
@@ -35,6 +34,7 @@ const SecuritiesTable = () => {
         <div className="securities-table-header">Exchange</div>
         <div className="securities-table-header">Symbol</div>
         <div className="securities-table-header">Name</div>
+        <div className="securities-table-header">Edit / Delete</div>
       </div>
       {isLoading ? (
         <div className="spinner-container">
@@ -55,6 +55,10 @@ const SecuritiesTable = () => {
                   </div>
                   <div className="securities-symbol-data">{item.symbol}</div>
                   <div className="securities-name-data">{item.name}</div>
+                  <div className="securities-row-options">
+                  <Link to="/inputform/edit"><div className="securities-edit-button"><button><span className="material-icons">edit</span></button></div></Link>
+                  <div className="securities-delete-button"><button><span className="material-icons">delete</span></button></div>
+                  </div>
                 </div>
               ))}
             </Components.ScrollWrapperY>

--- a/stockflux-securities-master/src/components/SecuritiesTable.js
+++ b/stockflux-securities-master/src/components/SecuritiesTable.js
@@ -4,6 +4,7 @@ import "./SecuritiesTable.css";
 import { Link } from "react-router-dom";
 import { getSecuritiesData } from "../services/SecuritiesService";
 import AddSecurityButton from "./AddSecurityButton";
+import ErrorDisplayer from "./ErrorDisplayer";
 
 const SecuritiesTable = () => {
   const [securitiesData, setSecuritiesData] = useState([]);
@@ -47,7 +48,7 @@ const SecuritiesTable = () => {
           <Components.LargeSpinner />
         </div>
       ) : errorMessage ? (
-        <div className="securities-error-message">{errorMessage}</div>
+        <ErrorDisplayer errorMessage={errorMessage} />
       ) : (
         <div className="table-body">
           {securitiesData.length > 0 ? (

--- a/stockflux-securities-master/src/components/SecuritiesTable.js
+++ b/stockflux-securities-master/src/components/SecuritiesTable.js
@@ -30,7 +30,12 @@ const SecuritiesTable = () => {
 
   return (
     <div className="securities-container">
-      <div className="securities-title">My Securities Table</div>
+      <div className="securities-title-container">
+        <div className="securities-title">My Securities Table</div>
+        <div className="add-securities-button-above-table">
+          {securitiesData.length > 0 && <AddSecurityButton />}
+        </div>
+      </div>
       <div className="header-container">
         <div className="securities-table-header">Exchange</div>
         <div className="securities-table-header">Symbol</div>
@@ -42,14 +47,10 @@ const SecuritiesTable = () => {
           <Components.LargeSpinner />
         </div>
       ) : errorMessage ? (
-        <div className="securities-error-message">
-          {errorMessage}
-        </div>
-        ) : (
-        <div>>
+        <div className="securities-error-message">{errorMessage}</div>
+      ) : (
+        <div className="table-body">
           {securitiesData.length > 0 ? (
-            <>
-            <div className="table-body">
             <Components.ScrollWrapperY>
               {securitiesData.map((item, index) => (
                 <div key={index} className="securities-table-row">
@@ -59,24 +60,28 @@ const SecuritiesTable = () => {
                   <div className="securities-symbol-data">{item.symbol}</div>
                   <div className="securities-name-data">{item.name}</div>
                   <div className="securities-row-options">
-                  <Link to="/inputform/edit"><div className="securities-edit-button"><button><span className="material-icons">edit</span></button></div></Link>
-                  <div className="securities-delete-button"><button><span className="material-icons">delete</span></button></div>
+                    <Link to="/inputform/edit">
+                      <div className="securities-edit-button">
+                        <button>
+                          <span className="material-icons">edit</span>
+                        </button>
+                      </div>
+                    </Link>
+                    <div className="securities-delete-button">
+                      <button disabled>
+                        <span className="material-icons">delete</span>
+                      </button>
+                    </div>
                   </div>
                 </div>
               ))}
             </Components.ScrollWrapperY>
-            </div>
-            <div className="add-security-button-container"><AddSecurityButton /></div>
-            </>
           ) : (
-            <div className="table-body">
-
             <div className="no-securities-container">
               <div className="no-securities-message">
                 You have no securities to show
               </div>
               <AddSecurityButton />
-            </div>
             </div>
           )}
         </div>

--- a/stockflux-securities-master/src/components/SecuritiesTable.js
+++ b/stockflux-securities-master/src/components/SecuritiesTable.js
@@ -31,9 +31,9 @@ const SecuritiesTable = () => {
   return (
     <div className="securities-container">
       <div className="securities-title-container">
-        <div className="securities-title">My Securities Table</div>
+        <div className="securities-title">Securities</div>
         <div className="add-securities-button-above-table">
-          {securitiesData.length > 0 && <AddSecurityButton />}
+          {securitiesData.length > 0  && !errorMessage && <AddSecurityButton size="small"/>}
         </div>
       </div>
       <div className="header-container">
@@ -81,7 +81,7 @@ const SecuritiesTable = () => {
               <div className="no-securities-message">
                 You have no securities to show
               </div>
-              <AddSecurityButton />
+              <AddSecurityButton size="large"/>
             </div>
           )}
         </div>

--- a/stockflux-securities-master/src/components/SecuritiesTable.js
+++ b/stockflux-securities-master/src/components/SecuritiesTable.js
@@ -4,7 +4,7 @@ import "./SecuritiesTable.css";
 import { Link } from "react-router-dom";
 import { getSecuritiesData } from "../services/SecuritiesService";
 import AddSecurityButton from "./AddSecurityButton";
-import ErrorDisplayer from "./ErrorDisplayer";
+import ErrorMessage from "./ErrorMessage";
 
 const SecuritiesTable = () => {
   const [securitiesData, setSecuritiesData] = useState([]);
@@ -13,7 +13,8 @@ const SecuritiesTable = () => {
 
   const [errorMessage, setErrorMessage] = useState(null);
 
-  const timeoutMessage = "Error, unable to get securities data. Please try again!";
+  const timeoutMessage =
+    "Error, unable to get securities data. Please try again!";
 
   useEffect(() => {
     setIsLoading(true);
@@ -34,7 +35,9 @@ const SecuritiesTable = () => {
       <div className="securities-title-container">
         <div className="securities-title">Securities</div>
         <div className="add-securities-button-above-table">
-          {securitiesData.length > 0  && !errorMessage && <AddSecurityButton size="small"/>}
+          {securitiesData.length > 0 && !errorMessage && (
+            <AddSecurityButton size="small" />
+          )}
         </div>
       </div>
       <div className="header-container">
@@ -48,7 +51,7 @@ const SecuritiesTable = () => {
           <Components.LargeSpinner />
         </div>
       ) : errorMessage ? (
-        <ErrorDisplayer errorMessage={errorMessage} />
+        <ErrorMessage errorMessage={errorMessage} />
       ) : (
         <div className="table-body">
           {securitiesData.length > 0 ? (
@@ -82,7 +85,7 @@ const SecuritiesTable = () => {
               <div className="no-securities-message">
                 You have no securities to show
               </div>
-              <AddSecurityButton size="large"/>
+              <AddSecurityButton size="large" />
             </div>
           )}
         </div>

--- a/stockflux-securities-master/src/components/SecuritiesTable.js
+++ b/stockflux-securities-master/src/components/SecuritiesTable.js
@@ -60,7 +60,7 @@ const SecuritiesTable = () => {
                   <div className="securities-symbol-data">{item.symbol}</div>
                   <div className="securities-name-data">{item.name}</div>
                   <div className="securities-row-options">
-                    <Link to="/inputform/edit">
+                    <Link to={`/inputform/${item.securityId}`}>
                       <div className="securities-edit-button">
                         <button>
                           <span className="material-icons">edit</span>


### PR DESCRIPTION
Edit buttons on the form have been created for each security row which routes to the input form with a title that says "Edit Security". The add security button has been refactored into it's own component and routes to the input form showing the title "Create a Security".  The title is chosen by the presence of a securityId prop. 
The add securities button is now present in the top right corner when there are securities in the table.