### PR TITLE
Make Get Security Service to Fill Edit Form

### DIFF
--- a/stockflux-securities-master/src/components/AddSecurityButton.css
+++ b/stockflux-securities-master/src/components/AddSecurityButton.css
@@ -1,12 +1,12 @@
 .add-security-button-small > button,
 .add-security-button-large > button {
-    border: solid 1px var(--text-teal);
-    background: none;
-    font-family: var(--font-roboto-sans-serif);
-    color: var(--text-teal-light);
-    font-weight: var(--font-weight-bolder);
-    border-radius: 25px;
-    text-align: center;
+  border: solid 1px var(--text-teal);
+  background: none;
+  font-family: var(--font-roboto-sans-serif);
+  color: var(--text-teal-light);
+  font-weight: var(--font-weight-bolder);
+  border-radius: 25px;
+  text-align: center;
 }
 
 .add-security-button-small > button:hover,
@@ -24,4 +24,9 @@
   height: 50px;
   width: 250px;
   font-size: var(--font-xxxlarge);
+}
+
+.add-security-button-small > button:focus,
+.add-security-button-large > button:focus {
+  outline: none;
 }

--- a/stockflux-securities-master/src/components/InputForm.css
+++ b/stockflux-securities-master/src/components/InputForm.css
@@ -32,17 +32,26 @@
   font-weight: var(--font-weight-bolder);
   margin: var(--margin-small);
   flex-basis: 80px;
-  }
+}
 
+.input-form-input-read-only,
 .input-form-input {
   font-size: var(--font-large);
   font-weight: var(--font-weight-normal);
-  color: var(--text-teal-light);
   background-color: var(--dark-background);
   border-radius: 25px;
-  border: solid 1px var(--text-teal);
-  padding: var(--padding-small) var(--padding-medium) ;
+  padding: var(--padding-small) var(--padding-medium);
   margin: var(--margin-small);
+}
+
+.input-form-input {
+  color: var(--text-teal-light);
+  border: solid 1px var(--text-teal);
+}
+
+.input-form-input-read-only {
+  color: var(--text-grey);
+  border: solid 1px var(--text-grey-darkest);
 }
 
 .input-form-input:focus {
@@ -110,6 +119,10 @@
   border-color: var(--text-grey-darkest);
 }
 
+.input-submit-button > button:hover {
+  color: var(--text-teal);
+}
+
 .input-submit-button > button:focus {
   outline: none;
 }
@@ -132,6 +145,10 @@
   border-radius: 20px;
   height: 30px;
   width: 70px;
+}
+
+.back-button > button:hover {
+  color: var(--text-teal);
 }
 
 .back-button > button:focus {

--- a/stockflux-securities-master/src/components/InputForm.css
+++ b/stockflux-securities-master/src/components/InputForm.css
@@ -34,8 +34,7 @@
   flex-basis: 80px;
 }
 
-.input-form-input-read-only,
-.input-form-input {
+.input-form {
   font-size: var(--font-large);
   font-weight: var(--font-weight-normal);
   background-color: var(--dark-background);
@@ -47,9 +46,15 @@
 .input-form-input {
   color: var(--text-teal-light);
   border: solid 1px var(--text-teal);
+  font-size: var(--font-large);
+  font-weight: var(--font-weight-normal);
+  background-color: var(--dark-background);
+  border-radius: 25px;
+  padding: var(--padding-small) var(--padding-medium);
+  margin: var(--margin-small);
 }
 
-.input-form-input-read-only {
+.input-form-input.read-only {
   color: var(--text-grey);
   border: solid 1px var(--text-grey-darkest);
 }

--- a/stockflux-securities-master/src/components/InputForm.js
+++ b/stockflux-securities-master/src/components/InputForm.js
@@ -73,8 +73,9 @@ const InputForm = ({ match }) => {
               Exchange
             </label>
             <input
-              className={`input-form-input${match.params.securityId &&
-                "-read-only"}`}
+              className={`input-form-input${
+                match.params.securityId ? "-read-only" : ""
+              }`}
               id="exchange-input"
               value={exchange}
               readOnly={match.params.securityId}
@@ -86,8 +87,9 @@ const InputForm = ({ match }) => {
               Symbol
             </label>
             <input
-              className={`input-form-input${match.params.securityId &&
-                "-read-only"}`}
+              className={`input-form-input${
+                match.params.securityId ? "-read-only" : ""
+              }`}
               id="symbol-input"
               value={symbol}
               readOnly={match.params.securityId}

--- a/stockflux-securities-master/src/components/InputForm.js
+++ b/stockflux-securities-master/src/components/InputForm.js
@@ -78,7 +78,7 @@ const InputForm = ({ match }) => {
               }`}
               id="exchange-input"
               value={exchange}
-              readOnly={match.params.securityId}
+              readOnly={!!match.params.securityId}
               onChange={event => setExchange(event.target.value)}
             />
           </div>
@@ -92,7 +92,7 @@ const InputForm = ({ match }) => {
               }`}
               id="symbol-input"
               value={symbol}
-              readOnly={match.params.securityId}
+              readOnly={!!match.params.securityId}
               onChange={event => setSymbol(event.target.value)}
             />
           </div>

--- a/stockflux-securities-master/src/components/InputForm.js
+++ b/stockflux-securities-master/src/components/InputForm.js
@@ -69,22 +69,12 @@ const InputForm = ({ match }) => {
       ) : (
         <form className="input-form-body" onSubmit={submitForm}>
           <div className="input-row">
-            <label className="input-label" htmlFor="name-input">
-              Name
-            </label>
-            <input
-              className="input-form-input"
-              id="name-input"
-              value={name}
-              onChange={event => setName(event.target.value)}
-            />
-          </div>
-          <div className="input-row">
             <label className="input-label" htmlFor="exchange-input">
               Exchange
             </label>
             <input
-              className="input-form-input"
+              className={`input-form-input${match.params.securityId &&
+                "-read-only"}`}
               id="exchange-input"
               value={exchange}
               readOnly={match.params.securityId}
@@ -96,11 +86,23 @@ const InputForm = ({ match }) => {
               Symbol
             </label>
             <input
-              className="input-form-input"
+              className={`input-form-input${match.params.securityId &&
+                "-read-only"}`}
               id="symbol-input"
               value={symbol}
               readOnly={match.params.securityId}
               onChange={event => setSymbol(event.target.value)}
+            />
+          </div>
+          <div className="input-row">
+            <label className="input-label" htmlFor="name-input">
+              Name
+            </label>
+            <input
+              className="input-form-input"
+              id="name-input"
+              value={name}
+              onChange={event => setName(event.target.value)}
             />
           </div>
           <div className="input-checkbox-container">

--- a/stockflux-securities-master/src/components/InputForm.js
+++ b/stockflux-securities-master/src/components/InputForm.js
@@ -44,11 +44,11 @@ const InputForm = ({ match }) => {
     setInProgress(true);
 
     const securityObject = {
-      name: name,
-      exchange: exchange,
-      symbol: symbol,
-      visible: visible,
-      enabled: enabled
+      name,
+      exchange,
+      symbol,
+      visible,
+      enabled
     };
 
     // call service

--- a/stockflux-securities-master/src/components/InputForm.js
+++ b/stockflux-securities-master/src/components/InputForm.js
@@ -73,9 +73,10 @@ const InputForm = ({ match }) => {
               Exchange
             </label>
             <input
-              className={`input-form-input${
-                match.params.securityId ? "-read-only" : ""
-              }`}
+              className={
+                (match.params.securityId ? "read-only " : "") +
+                "input-form-input"
+              }
               id="exchange-input"
               value={exchange}
               readOnly={!!match.params.securityId}
@@ -87,9 +88,10 @@ const InputForm = ({ match }) => {
               Symbol
             </label>
             <input
-              className={`input-form-input${
-                match.params.securityId ? "-read-only" : ""
-              }`}
+              className={
+                (match.params.securityId ? "read-only " : "") +
+                "input-form-input"
+              }
               id="symbol-input"
               value={symbol}
               readOnly={!!match.params.securityId}

--- a/stockflux-securities-master/src/components/InputForm.js
+++ b/stockflux-securities-master/src/components/InputForm.js
@@ -1,14 +1,43 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
+import Components from "stockflux-components";
 import { Link } from "react-router-dom";
 import "./InputForm.css";
+import { getSecurity } from "../services/SecuritiesService";
+import ErrorMessage from "./ErrorMessage";
 
 const InputForm = ({ match }) => {
   const [name, setName] = useState("");
   const [exchange, setExchange] = useState("");
   const [symbol, setSymbol] = useState("");
-  const [isShown, setIsShown] = useState(false);
-  const [isEnabled, setIsEnabled] = useState(false);
+  const [visible, setVisible] = useState(false);
+  const [enabled, setEnabled] = useState(false);
   const [inProgress, setInProgress] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState(null);
+
+  const setSecurityState = security => {
+    setName(security.name);
+    setExchange(security.exchange);
+    setSymbol(security.symbol);
+    setVisible(security.visible);
+    setEnabled(security.enabled);
+  };
+
+  useEffect(() => {
+    if (match.params.securityId) {
+      setIsLoading(true);
+      getSecurity(match.params.securityId)
+        .then(security => {
+          setIsLoading(false);
+          setErrorMessage(null);
+          setSecurityState(security);
+        })
+        .catch(() => {
+          setIsLoading(false);
+          setErrorMessage("Error, cannot get security");
+        });
+    }
+  }, []);
 
   const submitForm = event => {
     event.preventDefault();
@@ -16,10 +45,10 @@ const InputForm = ({ match }) => {
 
     const securityObject = {
       name: name,
-      exchangeId: exchange,
+      exchange: exchange,
       symbol: symbol,
-      isShown: isShown,
-      isEnabled: isEnabled
+      visible: visible,
+      enabled: enabled
     };
 
     // call service
@@ -30,75 +59,90 @@ const InputForm = ({ match }) => {
 
   return (
     <div className="input-form-container">
-      <div className="input-form-title">{match.params.securityId ? "Edit Security" : "Create a Security"}</div>
-      <form className="input-form-body" onSubmit={submitForm}>
-        <div className="input-row">
-          <label className="input-label" htmlFor="name-input">
-            Name
-          </label>
-          <input
-            className="input-form-input"
-            id="name-input"
-            value={name}
-            onChange={event => setName(event.target.value)}
-          />
-        </div>
-        <div className="input-row">
-          <label className="input-label" htmlFor="exchange-input">
-            Exchange
-          </label>
-          <input
-            className="input-form-input"
-            id="exchange-input"
-            value={exchange}
-            onChange={event => setExchange(event.target.value)}
-          />
-        </div>
-        <div className="input-row">
-          <label className="input-label" htmlFor="symbol-input">
-            Symbol
-          </label>
-          <input
-            className="input-form-input"
-            id="symbol-input"
-            value={symbol}
-            onChange={event => setSymbol(event.target.value)}
-          />
-        </div>
-        <div className="input-checkbox-container">
-          <label className="input-label" htmlFor="is-shown-toggle">
-            Is Shown
-          </label>
-          <input
-            className="input-form-toggle"
-            id="is-shown-toggle"
-            value={isShown}
-            type="checkbox"
-            onChange={() => setIsShown(!isShown)}
-          />
-          <label className="toggle-switch" htmlFor="is-shown-toggle" />
-        </div>
-        <div className="input-checkbox-container">
-          <label className="input-label" htmlFor="is-enabled-toggle">
-            Is Enabled
-          </label>
-          <input
-            className="input-form-toggle"
-            id="is-enabled-toggle"
-            value={isEnabled}
-            type="checkbox"
-            onChange={() => setIsEnabled(!isEnabled)}
-          />
-          <label className="toggle-switch" htmlFor="is-enabled-toggle" />
-        </div>
-        <div className="input-submit-button-container">
-          <div
-            className={(inProgress ? "in-progress " : "") + "input-submit-button"}
-          >
-            <button>Create</button>
+      <div className="input-form-title">
+        {match.params.securityId ? "Edit Security" : "Create a Security"}
+      </div>
+      {isLoading ? (
+        <Components.LargeSpinner />
+      ) : errorMessage ? (
+        <ErrorMessage errorMessage={errorMessage} />
+      ) : (
+        <form className="input-form-body" onSubmit={submitForm}>
+          <div className="input-row">
+            <label className="input-label" htmlFor="name-input">
+              Name
+            </label>
+            <input
+              className="input-form-input"
+              id="name-input"
+              value={name}
+              onChange={event => setName(event.target.value)}
+            />
           </div>
-        </div>
-      </form>
+          <div className="input-row">
+            <label className="input-label" htmlFor="exchange-input">
+              Exchange
+            </label>
+            <input
+              className="input-form-input"
+              id="exchange-input"
+              value={exchange}
+              readOnly={match.params.securityId}
+              onChange={event => setExchange(event.target.value)}
+            />
+          </div>
+          <div className="input-row">
+            <label className="input-label" htmlFor="symbol-input">
+              Symbol
+            </label>
+            <input
+              className="input-form-input"
+              id="symbol-input"
+              value={symbol}
+              readOnly={match.params.securityId}
+              onChange={event => setSymbol(event.target.value)}
+            />
+          </div>
+          <div className="input-checkbox-container">
+            <label className="input-label" htmlFor="is-shown-toggle">
+              Is Shown
+            </label>
+            <input
+              className="input-form-toggle"
+              id="visible-toggle"
+              value={visible}
+              checked={visible}
+              type="checkbox"
+              onChange={() => setVisible(!visible)}
+            />
+            <label className="toggle-switch" htmlFor="visible-toggle" />
+          </div>
+          <div className="input-checkbox-container">
+            <label className="input-label" htmlFor="is-enabled-toggle">
+              Is Enabled
+            </label>
+            <input
+              className="input-form-toggle"
+              id="enabled-toggle"
+              value={enabled}
+              checked={enabled}
+              type="checkbox"
+              onChange={() => setEnabled(!enabled)}
+            />
+            <label className="toggle-switch" htmlFor="enabled-toggle" />
+          </div>
+          <div className="input-submit-button-container">
+            <div
+              className={
+                (inProgress ? "in-progress " : "") + "input-submit-button"
+              }
+            >
+              <button>{match.params.securityId ? "Edit" : "Create"}</button>
+            </div>
+          </div>
+        </form>
+      )}
+
       <Link to="/">
         <div className="back-button">
           <button>

--- a/stockflux-securities-master/src/components/SecuritiesTable.css
+++ b/stockflux-securities-master/src/components/SecuritiesTable.css
@@ -86,7 +86,7 @@
   height: var(--table-body-height);
 }
 
-.no-securities-container{
+.no-securities-container {
   text-align: center;
   border-bottom: 1px solid var(--clr-divider-light);
 }
@@ -98,8 +98,7 @@
 }
 
 .securities-edit-button > button:focus,
-.securities-delete-button > button:focus,
-.add-security-button > button:focus {
+.securities-delete-button > button:focus {
   outline: none;
 }
 

--- a/stockflux-securities-master/src/components/SecuritiesTable.js
+++ b/stockflux-securities-master/src/components/SecuritiesTable.js
@@ -8,11 +8,8 @@ import ErrorMessage from "./ErrorMessage";
 
 const SecuritiesTable = () => {
   const [securitiesData, setSecuritiesData] = useState([]);
-
   const [isLoading, setIsLoading] = useState(true);
-
   const [errorMessage, setErrorMessage] = useState(null);
-
   const timeoutMessage =
     "Error, unable to get securities data. Please try again!";
 

--- a/stockflux-securities-master/src/services/SecuritiesService.js
+++ b/stockflux-securities-master/src/services/SecuritiesService.js
@@ -5,7 +5,18 @@ async function getWindowOptions() {
 
 export async function getSecuritiesData() {
   const options = await getWindowOptions();
-  const response = await fetch(`${options.customData.apiBaseUrl}/securities-v2`);
+  const response = await fetch(
+    `${options.customData.apiBaseUrl}/securities-v2`
+  );
   const securities = await response.json();
   return securities;
-}
+};
+
+export async function getSecurity(securityId) {
+  const options = await getWindowOptions();
+  const response = await fetch(
+    `${options.customData.apiBaseUrl}/securities-v2/${securityId}`
+  );
+  const security = await response.json();
+  return security;
+};


### PR DESCRIPTION
The service for getting a single security has been added and is used in the edit form to fill the form with the security data for the selected security. As discussed the exchange and symbol are read-only in the edit form. 