### PR TITLE
Feat: news app links

### DIFF
--- a/packages/stockflux-news/src/App.css
+++ b/packages/stockflux-news/src/App.css
@@ -4,11 +4,13 @@
 }
 
 .header {
-  font-size: var(--font-xxxlarge);
   color: var(--text-grey-lighter);
+  display:flex;
+  flex-direction: row;
+  font-size: var(--font-xxxlarge);
   font-weight: var(--font-weight-bolder);
+  justify-content: space-between;
   padding: 12px;
-  display: flex;
   height: var(--header-height);
   border-bottom: 1px solid var(--dark-background);
 }

--- a/packages/stockflux-news/src/App.css
+++ b/packages/stockflux-news/src/App.css
@@ -20,6 +20,10 @@
   height: calc(100vh - (var(--header-height) + var(--titlebar-height)));
 }
 
+.icons {
+  white-space: nowrap;
+}
+
 .no-articles {
   padding: var(--padding-medium);
   display: flex;

--- a/packages/stockflux-news/src/App.js
+++ b/packages/stockflux-news/src/App.js
@@ -91,7 +91,14 @@ function App() {
   return (
     <div className="stockflux-news">
       <Components.Titlebar />
-      <div className="header">{name ? name : symbol} News</div>
+      <div className="header">
+        <div>{name ? name : symbol} News</div>
+        <div>
+          {' '}
+          <Components.Shortcuts.Chart small={true} />
+          <Components.Shortcuts.Watchlist small={true} />
+        </div>
+      </div>
       <Components.ScrollWrapperY>
         <div className="container" ref={listContainer}>
           {isSearching ? (

--- a/packages/stockflux-news/src/App.js
+++ b/packages/stockflux-news/src/App.js
@@ -95,8 +95,16 @@ function App() {
         <div>{name ? name : symbol} News</div>
         <div>
           {' '}
-          <Components.Shortcuts.Chart small={true} />
-          <Components.Shortcuts.Watchlist small={true} />
+          <Components.Shortcuts.Chart
+            small={true}
+            symbol={symbol}
+            name={name}
+          />
+          <Components.Shortcuts.Watchlist
+            symbol={symbol}
+            name={name}
+            small={true}
+          />
         </div>
       </div>
       <Components.ScrollWrapperY>

--- a/packages/stockflux-news/src/App.js
+++ b/packages/stockflux-news/src/App.js
@@ -94,7 +94,6 @@ function App() {
       <div className="header">
         {name ? name : symbol} News
         <div className="icons">
-          {' '}
           <Components.Shortcuts.Chart
             small={true}
             symbol={symbol}

--- a/packages/stockflux-news/src/App.js
+++ b/packages/stockflux-news/src/App.js
@@ -92,8 +92,8 @@ function App() {
     <div className="stockflux-news">
       <Components.Titlebar />
       <div className="header">
-        <div>{name ? name : symbol} News</div>
-        <div>
+        {name ? name : symbol} News
+        <div className="icons">
           {' '}
           <Components.Shortcuts.Chart
             small={true}

--- a/packages/stockflux-news/src/App.js
+++ b/packages/stockflux-news/src/App.js
@@ -101,9 +101,9 @@ function App() {
             name={name}
           />
           <Components.Shortcuts.Watchlist
+            small={true}
             symbol={symbol}
             name={name}
-            small={true}
           />
         </div>
       </div>

--- a/packages/stockflux-news/src/index.css
+++ b/packages/stockflux-news/src/index.css
@@ -10,7 +10,7 @@ body {
 
 #root {
   height: 100%;
-  --header-height: 50px;
+  --header-height: 60px;
   --titlebar-height: 35px;
   --newsitem-height: 150px;
   --no-article-height: 30px;


### PR DESCRIPTION
For #1140 

* Add button links to StockFlux news on header

Appearance:

![image](https://user-images.githubusercontent.com/51117162/66326729-69d0e080-e921-11e9-8cf0-5cba01aad876.png)

Double line:

![image](https://user-images.githubusercontent.com/51117162/66326783-83722800-e921-11e9-837a-463768742e75.png)
