### PR TITLE
1297 undocked launcher search box

### DIFF
--- a/packages/stockflux-launcher/src/App.js
+++ b/packages/stockflux-launcher/src/App.js
@@ -36,7 +36,10 @@ export default () => {
     <div className={cx('app', edgeToBeChecked)}>
       {!isLauncherHorizontal(edgeToBeChecked) && CloseButton}
       <AppShortcuts />
-      <FreeTextSearch dockedTo={edge} />
+      <FreeTextSearch
+        dockedTo={edge}
+        showTextInput={!isLauncherHorizontal(edgeToBeChecked)}
+      />
       <ToolBar
         tools={[
           {

--- a/packages/stockflux-launcher/src/free-text-search/FreeTextSearch.js
+++ b/packages/stockflux-launcher/src/free-text-search/FreeTextSearch.js
@@ -29,7 +29,7 @@ const SEARCH_RESULTS_WINDOW_NAME = 'search-results';
 const SEARCH_RESULTS_CSS_PATCH = 'childWindow.css';
 
 let latestRequest = null;
-const FreeTextSearch = ({ dockedTo }) => {
+const FreeTextSearch = ({ dockedTo, showTextInput }) => {
   const [searchState, dispatch] = useReducer(reducer, initialSearchState);
   const [query, setQuery] = useState(null);
   const [parentUuid, setParentUuid] = useState(null);
@@ -53,7 +53,7 @@ const FreeTextSearch = ({ dockedTo }) => {
     );
   }, []);
 
-  const isDockedToSide = [ScreenEdge.LEFT, ScreenEdge.RIGHT].includes(dockedTo);
+  const isDockedToSide = [ScreenEdge.LEFT, ScreenEdge.RIGHT].includes(dockedTo);  
 
   const launchChildWindow = useCallback(
     () =>
@@ -142,7 +142,7 @@ const FreeTextSearch = ({ dockedTo }) => {
           isSearching={isSearching}
           debouncedQuery={debouncedQuery}
         >
-          {isDockedToSide && (
+          {(isDockedToSide || showTextInput) && (
             <div className="free-text-search">
               <SearchInputField
                 query={query ? query : ''}
@@ -164,7 +164,8 @@ const FreeTextSearch = ({ dockedTo }) => {
     results,
     handleOnInputChange,
     isDockedToSide,
-    query
+    query,
+    showTextInput
   ]);
 
   const {

--- a/packages/stockflux-launcher/src/free-text-search/FreeTextSearch.js
+++ b/packages/stockflux-launcher/src/free-text-search/FreeTextSearch.js
@@ -53,7 +53,7 @@ const FreeTextSearch = ({ dockedTo, showTextInput }) => {
     );
   }, []);
 
-  const isDockedToSide = [ScreenEdge.LEFT, ScreenEdge.RIGHT].includes(dockedTo);  
+  const isDockedToSide = [ScreenEdge.LEFT, ScreenEdge.RIGHT].includes(dockedTo);
 
   const launchChildWindow = useCallback(
     () =>

--- a/packages/stockflux-launcher/src/search-results/helpers/Positioner.js
+++ b/packages/stockflux-launcher/src/search-results/helpers/Positioner.js
@@ -17,7 +17,7 @@ export default (searchButtonRef, inputRef, dockedTo, windowBounds) => {
     case ScreenEdge.LEFT:
       return {
         defaultTop: parseInt(searchButtonRect.top),
-        defaultLeft: DEFAULT_LAUNCHER_SIZE,
+        defaultLeft: windowBounds.right,
         defaultWidth: DEFAULT_SEARCH_RESULTS_SIZE,
         defaultHeight: DEFAULT_SEARCH_RESULTS_SIZE
       };

--- a/packages/stockflux-launcher/src/search-results/helpers/Positioner.js
+++ b/packages/stockflux-launcher/src/search-results/helpers/Positioner.js
@@ -43,11 +43,10 @@ export default (searchButtonRef, inputRef, dockedTo, windowBounds) => {
         let leftPosition = windowBounds.left + windowBounds.width;
         if (rightPosition > window.screen.width) {
           leftPosition = windowBounds.left - DEFAULT_SEARCH_RESULTS_SIZE;
-        } else {
-          if (windowBounds.left < 0 && rightPosition > 0) {
-            leftPosition = windowBounds.left - DEFAULT_SEARCH_RESULTS_SIZE;
-          }
+        } else if (windowBounds.left < 0 && rightPosition > 0) {
+          leftPosition = windowBounds.left - DEFAULT_SEARCH_RESULTS_SIZE;
         }
+
         return {
           defaultTop: parseInt(searchButtonRect.top),
           defaultLeft: leftPosition,

--- a/packages/stockflux-launcher/src/search-results/helpers/Positioner.js
+++ b/packages/stockflux-launcher/src/search-results/helpers/Positioner.js
@@ -29,11 +29,31 @@ export default (searchButtonRef, inputRef, dockedTo, windowBounds) => {
         defaultHeight: DEFAULT_SEARCH_RESULTS_SIZE
       };
     default:
-      return {
-        defaultTop: 0,
-        defaultLeft: 0,
-        defaultWidth: DEFAULT_SEARCH_RESULTS_SIZE,
-        defaultHeight: DEFAULT_SEARCH_RESULTS_SIZE
-      };
+      const searchInputBox = inputRef.current.getBoundingClientRect();
+      if (searchInputBox.x !== 0) {
+        return {
+          defaultTop: parseInt(windowBounds.top) + DEFAULT_LAUNCHER_SIZE,
+          defaultLeft: windowBounds.left + parseInt(searchInputBox.left),
+          defaultWidth: DEFAULT_SEARCH_RESULTS_SIZE,
+          defaultHeight: DEFAULT_SEARCH_RESULTS_SIZE
+        };
+      } else {
+        const rightPosition =
+          windowBounds.left + windowBounds.width + DEFAULT_SEARCH_RESULTS_SIZE;
+        let leftPosition = windowBounds.left + windowBounds.width;
+        if (rightPosition > window.screen.width) {
+          leftPosition = windowBounds.left - DEFAULT_SEARCH_RESULTS_SIZE;
+        } else {
+          if (windowBounds.left < 0 && rightPosition > 0) {
+            leftPosition = windowBounds.left - DEFAULT_SEARCH_RESULTS_SIZE;
+          }
+        }
+        return {
+          defaultTop: parseInt(searchButtonRect.top),
+          defaultLeft: leftPosition,
+          defaultWidth: DEFAULT_SEARCH_RESULTS_SIZE,
+          defaultHeight: DEFAULT_SEARCH_RESULTS_SIZE
+        };
+      }
   }
 };


### PR DESCRIPTION
From Issue #1297 When the launcher bar is undocked the search results box appears in the 0,0 position. 

![image](https://user-images.githubusercontent.com/49903895/66761679-63e87b80-ee9c-11e9-96e5-def7dac55aae.png)
![image](https://user-images.githubusercontent.com/49903895/66761736-7b276900-ee9c-11e9-91f9-626b55dc786c.png)

Fixed to work out where it should be showing from the window, works in both formats of the launcher (Horizontal / Vertical) and will handle if the launcher is dragged onto non-primary monitors. Should work on all sizes of launchers. 