### PR TITLE
Flag to allow multiple instances of window

### DIFF
--- a/packages/stockflux-core/src/services/ChildWindowLauncher.js
+++ b/packages/stockflux-core/src/services/ChildWindowLauncher.js
@@ -1,8 +1,8 @@
 import * as OpenfinApiHelpers from '../openfin-api-utils/openfinApiHelpers';
 
 const windowAlreadyExist = async (windowName, childWindows) => {
-  for (let i = 0; i < childWindows.length; i++) {
-    const childWindowOptions = await childWindows[i].getOptions();
+  for (const childWindow of childWindows) {
+    const childWindowOptions = await childWindow.getOptions();
     if (childWindowOptions.name === windowName) {
       return true;
     }

--- a/packages/stockflux-core/src/services/ChildWindowLauncher.js
+++ b/packages/stockflux-core/src/services/ChildWindowLauncher.js
@@ -1,18 +1,44 @@
 import * as OpenfinApiHelpers from '../openfin-api-utils/openfinApiHelpers';
 
+const windowAlreadyExist = async (windowName, childWindows) => {
+  for (let i = 0; i < childWindows.length; i++) {
+    const childWindowOptions = await childWindows[i].getOptions();
+    if (childWindowOptions.name === windowName) {
+      return true;
+    }
+  }
+  return false;
+};
+
 const createChildWindow = async options => {
   const childWindows = await OpenfinApiHelpers.getChildWindows();
   const currentOptions = await OpenfinApiHelpers.getCurrentWindowOptions();
 
   options.uuid = currentOptions.uuid;
-  for (let i = 0; i < childWindows.length; i++) {
-    const childWindowOptions = await childWindows[i].getOptions();
-    if (childWindowOptions.name === options.name) {
-      if (childWindows[i]) {
-        childWindows[i].bringToFront();
-        return true;
+
+  if (options.allowMultiple) {
+    if (await windowAlreadyExist(options.name, childWindows)) {
+      let windowNumber = 1;
+      while (
+        await windowAlreadyExist(
+          `${options.name} ${windowNumber}`,
+          childWindows
+        )
+      ) {
+        windowNumber++;
       }
-      break;
+      options.name = `${options.name} ${windowNumber}`;
+    }
+  } else {
+    for (let i = 0; i < childWindows.length; i++) {
+      const childWindowOptions = await childWindows[i].getOptions();
+      if (childWindowOptions.name === options.name) {
+        if (childWindows[i]) {
+          childWindows[i].bringToFront();
+          return true;
+        }
+        break;
+      }
     }
   }
 

--- a/packages/stockflux-core/src/services/app-launchers/Chart.js
+++ b/packages/stockflux-core/src/services/app-launchers/Chart.js
@@ -10,6 +10,7 @@ const launchAsIntent = (symbol, name) =>
 const launchAsChildWindow = async (symbol, name) =>
   launchChildWindow(await getStockFluxApp(APP_NAME), options => {
     options.name = `${APP_NAME}${symbol ? `[${symbol}]` : ''}`;
+    options.allowMultiple = true;
     if (symbol) {
       options.customData.symbol = symbol;
     }

--- a/packages/stockflux-core/src/services/app-launchers/News.js
+++ b/packages/stockflux-core/src/services/app-launchers/News.js
@@ -10,6 +10,7 @@ const launchAsIntent = (symbol, name) =>
 const launchAsChildWindow = async (symbol, name) =>
   launchChildWindow(await getStockFluxApp(APP_NAME), options => {
     options.name = `${APP_NAME}${symbol ? `[${symbol}]` : ''}`;
+    options.allowMultiple = true;
     if (symbol) {
       options.customData.symbol = symbol;
     }


### PR DESCRIPTION
For issue #1154, added a flag to the Chart and News launcher which allow multiple instances of them to be open at one time. 
![image](https://user-images.githubusercontent.com/49903895/66827525-ceee8c80-ef46-11e9-9850-a8e7e68a9b3e.png)
Each instance of a window after the first has a number appended to its name, numbers are reused again if the window is closed, and a new one spawned. 
Within the launcher if you pass `options.allowMultiple = true` to LaunchAsChildWindow this will allow multiple instances, if the flag is missing or false it reverts to previous behaviour and only allows a single instance of the screen to show. 

This only works with lauchAsChildWindow, and does not work with intent launchers. 

