### PR TITLE
Refactor: Move all use of OpenFin API into stockflux-core

### DIFF
--- a/packages/stockflux-chart/src/index.js
+++ b/packages/stockflux-chart/src/index.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { OpenfinApiHelpers } from 'stockflux-core';
 import App from './App';
 
 const mountApp = () => {
   ReactDOM.render(<App />, document.getElementById('root'));
 };
 
-if (window.fin) {
+if (OpenfinApiHelpers.getWindow()) {
   mountApp();
 } else {
   console.error('This application can only be run in an OpenFin container.');

--- a/packages/stockflux-container/src/App.js
+++ b/packages/stockflux-container/src/App.js
@@ -10,7 +10,7 @@ let latestNewsListener;
 let windows = [];
 
 function App() {
-  const { InterApplicationBus } = window.fin;
+  const { InterApplicationBus } = OpenfinApiHelpers.getWindow();
   const [options] = useOptions();
 
   const createWindow = async (context, windowName) => {

--- a/packages/stockflux-core/src/index.js
+++ b/packages/stockflux-core/src/index.js
@@ -16,7 +16,9 @@ import {
   getAllApps,
   getStockFluxApps,
   getStockFluxApp,
-  sendInterApplicationMessage
+  getWindow,
+  sendInterApplicationMessage,
+  useMain
 } from './openfin-api-utils/openfinApiHelpers';
 import { launchChildWindow } from './services/ChildWindowLauncher';
 import {
@@ -38,7 +40,9 @@ export const OpenfinApiHelpers = {
   getAllApps,
   getStockFluxApps,
   getStockFluxApp,
-  sendInterApplicationMessage
+  getWindow,
+  sendInterApplicationMessage,
+  useMain
 };
 
 export const StockFlux = {

--- a/packages/stockflux-core/src/index.js
+++ b/packages/stockflux-core/src/index.js
@@ -17,7 +17,9 @@ import {
   getStockFluxApps,
   getStockFluxApp,
   getWindow,
+  openUrlWithBrowser,
   sendInterApplicationMessage,
+  showNotification,
   useMain
 } from './openfin-api-utils/openfinApiHelpers';
 import { launchChildWindow } from './services/ChildWindowLauncher';
@@ -41,7 +43,9 @@ export const OpenfinApiHelpers = {
   getStockFluxApps,
   getStockFluxApp,
   getWindow,
+  openUrlWithBrowser,
   sendInterApplicationMessage,
+  showNotification,
   useMain
 };
 

--- a/packages/stockflux-core/src/openfin-api-utils/openfinApiHelpers.js
+++ b/packages/stockflux-core/src/openfin-api-utils/openfinApiHelpers.js
@@ -45,5 +45,12 @@ export const getStockFluxApp = async appId =>
     )
     .then(response => response.json());
 
+export const getWindow = async () => {
+  return await window.fin;
+};
+
 export const sendInterApplicationMessage = async (uuid, topic, payload) =>
   await window.fin.InterApplicationBus.send({ uuid }, topic, payload);
+
+export const useMain = async mountApp =>
+  await window.fin.desktop.main(mountApp);

--- a/packages/stockflux-core/src/openfin-api-utils/openfinApiHelpers.js
+++ b/packages/stockflux-core/src/openfin-api-utils/openfinApiHelpers.js
@@ -49,8 +49,19 @@ export const getWindow = async () => {
   return await window.fin;
 };
 
+export const openUrlWithBrowser = async url => {
+  await window.fin.desktop.System.openUrlWithBrowser(url);
+};
+
 export const sendInterApplicationMessage = async (uuid, topic, payload) =>
   await window.fin.InterApplicationBus.send({ uuid }, topic, payload);
+
+export const showNotification = async (url, message) => {
+  return new window.fin.desktop.Notification({
+    url: url,
+    message: message
+  });
+};
 
 export const useMain = async mountApp =>
   await window.fin.desktop.main(mountApp);

--- a/packages/stockflux-launcher/src/index.js
+++ b/packages/stockflux-launcher/src/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { OpenfinApiHelpers } from 'stockflux-core';
 import App from './App';
 
 import './index.css';
@@ -8,8 +9,8 @@ const mountApp = () => {
   ReactDOM.render(<App />, document.getElementById('root'));
 };
 
-if (window.fin) {
-  window.fin.desktop.main(mountApp);
+if (OpenfinApiHelpers.getWindow()) {
+  OpenfinApiHelpers.useMain(mountApp);
 } else {
   console.error('This application can only be run in an OpenFin container.');
 }

--- a/packages/stockflux-watchlist/src/components/notifications/Notification.js
+++ b/packages/stockflux-watchlist/src/components/notifications/Notification.js
@@ -1,9 +1,6 @@
-/*global fin*/
+import { OpenfinApiHelpers } from 'stockflux-core';
 
 export const showNotification = notificationDetails => {
   const details = notificationDetails;
-  new fin.desktop.Notification({
-    url: './notification.html',
-    message: details.message
-  });
+  OpenfinApiHelpers.showNotification('./notification.html', details.message);
 };

--- a/packages/stockflux-watchlist/src/components/watchlist-card/WatchlistCard.js
+++ b/packages/stockflux-watchlist/src/components/watchlist-card/WatchlistCard.js
@@ -178,8 +178,8 @@ const WatchlistCard = ({
                     {Math.abs(stockData.percentage) + '%'}
                   </>
                 ) : (
-                    ''
-                  )}
+                  ''
+                )}
               </div>
             </div>
           </div>
@@ -187,8 +187,8 @@ const WatchlistCard = ({
       </div>
     </div>
   ) : (
-      <></>
-    );
+    <></>
+  );
 };
 
 WatchlistCard.propTypes = {

--- a/packages/stockflux-watchlist/src/components/watchlist-card/WatchlistCard.js
+++ b/packages/stockflux-watchlist/src/components/watchlist-card/WatchlistCard.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { OpenfinApiHelpers } from 'stockflux-core';
 import * as PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { FaTimes } from 'react-icons/fa';
@@ -98,7 +99,7 @@ const WatchlistCard = ({
 
   const sendSymbolToNews = () => {
     try {
-      window.fin.InterApplicationBus.send(
+      OpenfinApiHelpers.sendInterApplicationMessage(
         { uuid: options ? options.uuid : '*' },
         'news',
         {
@@ -177,8 +178,8 @@ const WatchlistCard = ({
                     {Math.abs(stockData.percentage) + '%'}
                   </>
                 ) : (
-                  ''
-                )}
+                    ''
+                  )}
               </div>
             </div>
           </div>
@@ -186,8 +187,8 @@ const WatchlistCard = ({
       </div>
     </div>
   ) : (
-    <></>
-  );
+      <></>
+    );
 };
 
 WatchlistCard.propTypes = {

--- a/packages/stockflux-watchlist/src/index.js
+++ b/packages/stockflux-watchlist/src/index.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { OpenfinApiHelpers } from 'stockflux-core';
 import App from './App';
 
 const mountApp = () => {
   ReactDOM.render(<App />, document.getElementById('root'));
 };
 
-if (window.fin) {
-  window.fin.desktop.main(mountApp);
+if (OpenfinApiHelpers.getWindow()) {
+  OpenfinApiHelpers.useMain(mountApp);
 } else {
   console.error('This application can only be run in an OpenFin container.');
 }

--- a/packages/stockflux-watchlist/src/services/currentWindowService.js
+++ b/packages/stockflux-watchlist/src/services/currentWindowService.js
@@ -1,11 +1,11 @@
-/*global fin*/
+import { OpenfinApiHelpers } from 'stockflux-core';
 
 /**
  * Abstraction layer for the OpenFin API.
  */
 class CurrentWindowService {
   getCurrentWindow() {
-    return fin.desktop.Window.getCurrent();
+    return OpenfinApiHelpers.getCurrent();
   }
 
   getCurrentWindowName() {
@@ -13,11 +13,11 @@ class CurrentWindowService {
   }
 
   ready(cb) {
-    fin.desktop.main(cb);
+    OpenfinApiHelpers.useMain(cb);
   }
 
   openUrlWithBrowser(url) {
-    fin.desktop.System.openUrlWithBrowser(url);
+    OpenfinApiHelpers.openUrlWithBrowser(url);
   }
 
   resizeTo(...args) {

--- a/packages/stockflux-watchlist/src/services/currentWindowService.js
+++ b/packages/stockflux-watchlist/src/services/currentWindowService.js
@@ -5,7 +5,7 @@ import { OpenfinApiHelpers } from 'stockflux-core';
  */
 class CurrentWindowService {
   getCurrentWindow() {
-    return OpenfinApiHelpers.getCurrent();
+    return OpenfinApiHelpers.getCurrentWindow();
   }
 
   getCurrentWindowName() {


### PR DESCRIPTION
Fixes #1182 

* Refactors any uses of `window.fin` or `fin.` to use `OpenfinApiHelpers`