### PR TITLE
change styling on scrollbars

### DIFF
--- a/packages/stockflux-components/src/components/scroll-wrapper-y/ScrollWrapperY.css
+++ b/packages/stockflux-components/src/components/scroll-wrapper-y/ScrollWrapperY.css
@@ -1,14 +1,7 @@
 .scrollWrapperY {
   flex: 1 1 auto;
   position: relative;
-  overflow-y: hidden;
+  overflow-y: scroll;
   overflow-x: hidden;
-  -webkit-transition: 0.6s padding-right;
-  transition: 0.6s padding-right;
   height: inherit;
-}
-
-.scrollPaddingRight:hover {
-  padding-right: 13px;
-  overflow: overlay;
 }

--- a/packages/stockflux-components/src/index.css
+++ b/packages/stockflux-components/src/index.css
@@ -43,6 +43,7 @@
   /* Scroll Bars */
   --scroll-bar-background:#0D2437;
   --scroll-bar-inactive:#8A96A6;
+  --scroll-bar-arrow:#8A96A6;
   --scroll-bar-track:#1B3B56;
   --scroll-bar-grip:#091A29;
   /* Icons */

--- a/packages/stockflux-components/src/styles/scrollbar.css
+++ b/packages/stockflux-components/src/styles/scrollbar.css
@@ -3,11 +3,11 @@
 }
 
 ::-webkit-scrollbar-track {
-    background: rgba(0,0,0,.1);
+    background-color: var(--scroll-bar-track);
     border-radius: 0;
 }
 
 ::-webkit-scrollbar-thumb {
     border-radius: 5px;
-    background: rgba(0,0,0,.25);
+    background-color:  var(--scroll-bar-grip);
 }


### PR DESCRIPTION
Merge scrollbar changes into general UX feedback. 
- Remove hover to show scrollbar functionality
- change colours to use from `index.css` variables. 
![image](https://user-images.githubusercontent.com/49903895/67388507-b3abfe80-f590-11e9-8d8b-9487e66c3913.png)
Currently does not have the up/down arrows, need more research into webkit-scrollbar to get them to show correctly.
