### PR TITLE
Chart click option

### DIFF
--- a/packages/stockflux-watchlist/src/components/watchlist-card/WatchlistCard.js
+++ b/packages/stockflux-watchlist/src/components/watchlist-card/WatchlistCard.js
@@ -4,7 +4,7 @@ import * as PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Minichart from '../minichart/Minichart';
 import Components from 'stockflux-components';
-import { StockFlux, Intents, Utils } from 'stockflux-core';
+import { StockFlux, Utils } from 'stockflux-core';
 import currentWindowService from '../../services/currentWindowService';
 import { useOptions } from 'openfin-react-hooks';
 import './WatchlistCard.css';
@@ -162,7 +162,7 @@ const WatchlistCard = ({
           </div>
           <div
             className="card-bottom"
-            onClick={() => Intents.viewChart(symbol, stockData.name)}
+            onClick={() => bindings.onDropOutside(symbol, stockData.name)}
           >
             <Minichart
               symbol={symbol}

--- a/packages/stockflux-watchlist/src/components/watchlist/Watchlist.js
+++ b/packages/stockflux-watchlist/src/components/watchlist/Watchlist.js
@@ -24,8 +24,8 @@ const Watchlist = () => {
   const [dragOverIndex, setDragOverIndex] = useState(null);
   const [unwatchedSymbol, setUnwatchedSymbol] = useState(null);
   const [displayPreview, setDisplayPreview] = useState(false);
+  const [windowOptions, setWindowOptions] = useState(null);
   const [previewDetails, setPreviewDetails] = useState({
-    options: null,
     position: { top: 0, left: 0 },
     size: { height: 300, width: 300 }
   });
@@ -33,6 +33,7 @@ const Watchlist = () => {
     'watchlist',
     ['AAPL', 'AAP', 'CC', 'MS', 'JPS']
   );
+  const WINDOW_OFFSET = 5;
 
   const [options] = useOptions();
 
@@ -92,7 +93,14 @@ const Watchlist = () => {
   const getSymbolIndex = symbol => watchlist.indexOf(symbol);
 
   const onDropOutside = (symbol, stockName) => {
-    Launchers.launchChart(symbol, stockName, previewDetails.position);
+    if (windowOptions) {
+      /*Always recalculate where the target window should drop, for is the window has been moved. */
+      const dropPosition = {
+        left: calcLeftPosition(windowOptions.defaultWidth, WINDOW_OFFSET),
+        top: window.screenTop
+      };
+      Launchers.launchChart(symbol, stockName, dropPosition);
+    }
   };
 
   const bindings = {
@@ -137,7 +145,7 @@ const Watchlist = () => {
 
   useEffect(() => {
     getWindowOptions().then(value => {
-      setPreviewDetails({ ...previewDetails, options: value });
+      setWindowOptions(value);
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -162,26 +170,21 @@ const Watchlist = () => {
       : window.outerWidth + screenLeft() + offset;
 
   useEffect(() => {
-    const WINDOW_OFFSET = 5;
-
-    if (previewDetails.options) {
+    if (windowOptions) {
       setPreviewDetails({
         ...previewDetails,
         position: {
-          left: calcLeftPosition(
-            previewDetails.options.defaultWidth,
-            WINDOW_OFFSET
-          ),
+          left: calcLeftPosition(windowOptions.defaultWidth, WINDOW_OFFSET),
           top: window.screenTop
         },
         size: {
-          height: previewDetails.options.defaultHeight,
-          width: previewDetails.options.defaultWidth
+          height: windowOptions.defaultHeight,
+          width: windowOptions.defaultWidth
         }
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [displayPreview]);
+  }, [displayPreview, windowOptions]);
 
   return (
     <div
@@ -226,6 +229,7 @@ const Watchlist = () => {
                 dragOverIndex === watchlist.length && i === watchlist.length - 1
               }
               removeFromWatchList={removeFromWatchList}
+              chartPosition={previewDetails}
             />
           ))
         )}

--- a/packages/stockflux-watchlist/src/components/watchlist/Watchlist.js
+++ b/packages/stockflux-watchlist/src/components/watchlist/Watchlist.js
@@ -229,7 +229,6 @@ const Watchlist = () => {
                 dragOverIndex === watchlist.length && i === watchlist.length - 1
               }
               removeFromWatchList={removeFromWatchList}
-              chartPosition={previewDetails}
             />
           ))
         )}


### PR DESCRIPTION
Restore functionality to the watch list cards. From when intents were used clicking on the chart in the watch list would open the chart. When intents were removed this no longer worked.

This restores the functionality using new methods which includes the window positioning correctly. 