### PR TITLE
change watchlist minichart size

### DIFF
--- a/packages/stockflux-watchlist/src/App.css
+++ b/packages/stockflux-watchlist/src/App.css
@@ -18,7 +18,7 @@
 
   /* Minichart Variables --------------*/
   /*-----------------------------------*/
-  --minichart-width: 162px;
+  --minichart-width: 153px;
   --minichart-height: 60px;
   --chart-stroke: var(--chart-teal);
 

--- a/packages/stockflux-watchlist/src/components/minichart/constants.js
+++ b/packages/stockflux-watchlist/src/components/minichart/constants.js
@@ -1,5 +1,5 @@
 // Minichart Dimensions in px
-const WIDTH = 162;
+const WIDTH = 153;
 const HEIGHT = 60;
 const PADDING_LEFT = 0;
 const PADDING_RIGHT = 0;


### PR DESCRIPTION
Modify the mini-chart on the watch list to be smaller to allow for 6 digit stock prices.
Before - 
![image](https://user-images.githubusercontent.com/49903895/67934394-ba092e80-fbbf-11e9-8461-248d0ca018d6.png)
After - 
![image](https://user-images.githubusercontent.com/49903895/67934351-a5c53180-fbbf-11e9-8425-594d82d5b5fd.png)
