### PR TITLE
News: Change layout to new ux standard

### DIFF
--- a/packages/stockflux-components/src/index.css
+++ b/packages/stockflux-components/src/index.css
@@ -61,7 +61,7 @@
 
   /* padding */
   --padding-small: 5px;
-  --padding-medium: 10px;
+  --padding-medium: 12px;
   --padding-large: 15px;
   --padding-xlarge: 20px;
 

--- a/packages/stockflux-news/src/App.css
+++ b/packages/stockflux-news/src/App.css
@@ -3,30 +3,9 @@
   background-color: var(--window-background-color);
 }
 
-.tab-bar {
-  height: var(--tabbar-height);
-  display:flex;
-  flex-direction: row;      
-  
-}
-
-.news-tab {
-  flex-grow:1;
-  border: var(--window-divider) 1px solid;
-  display:flex;
-  align-items: center;
-  justify-content: center;
-  padding-left: 6px;
-  padding-right: 6px;
-}
-
-.news-tab:hover {
-  background-color: var(--color-hover);
-}
-
 .container {
   max-height: 700px;
-  height: calc(100vh - (var(--tabbar-height) + var(--titlebar-height)));
+  height: calc(100vh - var(--titlebar-height));
 }
 
 .icons {

--- a/packages/stockflux-news/src/App.css
+++ b/packages/stockflux-news/src/App.css
@@ -1,23 +1,32 @@
 .stockflux-news {
   height: 100%;
-  background-color: var(--middle-background);
+  background-color: var(--window-background-color);
 }
 
-.header {
-  color: var(--text-grey-lighter);
+.tab-bar {
+  height: var(--tabbar-height);
   display:flex;
-  flex-direction: row;
-  font-size: var(--font-xxxlarge);
-  font-weight: var(--font-weight-bolder);
-  justify-content: space-between;
-  padding: 12px;
-  height: var(--header-height);
-  border-bottom: 1px solid var(--dark-background);
+  flex-direction: row;      
+  
+}
+
+.news-tab {
+  flex-grow:1;
+  border: var(--window-divider) 1px solid;
+  display:flex;
+  align-items: center;
+  justify-content: center;
+  padding-left: 6px;
+  padding-right: 6px;
+}
+
+.news-tab:hover {
+  background-color: var(--color-hover);
 }
 
 .container {
   max-height: 700px;
-  height: calc(100vh - (var(--header-height) + var(--titlebar-height)));
+  height: calc(100vh - (var(--tabbar-height) + var(--titlebar-height)));
 }
 
 .icons {

--- a/packages/stockflux-news/src/App.js
+++ b/packages/stockflux-news/src/App.js
@@ -48,7 +48,6 @@ function App() {
 
   const [searchState, dispatch] = useReducer(searchReducer, initialSearchState);
   const [symbol, setSymbol] = useState(null);
-  const [name, setName] = useState(null);
   const [options] = useOptions();
   const listContainer = useRef(null);
 
@@ -71,11 +70,7 @@ function App() {
     if (options && options.customData.symbol) {
       setSymbol(options.customData.symbol);
     }
-
-    if (options && options.customData.name) {
-      setName(options.customData.name);
-    }
-  }, [options, setName, setSymbol, symbol]);
+  }, [options, setSymbol, symbol]);
 
   useEffect(() => {
     if (symbol) {

--- a/packages/stockflux-news/src/App.js
+++ b/packages/stockflux-news/src/App.js
@@ -86,11 +86,6 @@ function App() {
   return (
     <div className="stockflux-news">
       <Components.Titlebar title="News" />
-      <div className="tab-bar">
-        <div className="news-tab">{symbol}</div>
-        <div className="news-tab">A.N.OTHR</div>
-        <div className="news-tab">MISC</div>
-      </div>
       <Components.ScrollWrapperY>
         <div className="container" ref={listContainer}>
           {isSearching ? (

--- a/packages/stockflux-news/src/App.js
+++ b/packages/stockflux-news/src/App.js
@@ -90,21 +90,11 @@ function App() {
 
   return (
     <div className="stockflux-news">
-      <Components.Titlebar />
-      <div className="header">
-        {name ? name : symbol} News
-        <div className="icons">
-          <Components.Shortcuts.Chart
-            small={true}
-            symbol={symbol}
-            name={name}
-          />
-          <Components.Shortcuts.Watchlist
-            small={true}
-            symbol={symbol}
-            name={name}
-          />
-        </div>
+      <Components.Titlebar title="News" />
+      <div className="tab-bar">
+        <div className="news-tab">{symbol}</div>
+        <div className="news-tab">A.N.OTHR</div>
+        <div className="news-tab">MISC</div>
       </div>
       <Components.ScrollWrapperY>
         <div className="container" ref={listContainer}>

--- a/packages/stockflux-news/src/components/news-item/NewsItem.css
+++ b/packages/stockflux-news/src/components/news-item/NewsItem.css
@@ -20,7 +20,7 @@
 
 .newsitem-content {
     padding-top: var(--padding-small);
-    width: 75%;
+    width: 100%;
     max-height: 80px;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/packages/stockflux-news/src/components/news-item/NewsItem.css
+++ b/packages/stockflux-news/src/components/news-item/NewsItem.css
@@ -5,14 +5,11 @@
     cursor: pointer;
     flex-direction: column;
     padding: var(--padding-medium);
-}
-
-.newsitem:not(:first-child) {
-    border-top: 1px solid var(--middle-background-lighter);
+    border-top: 2px solid var(--window-divider);
 }
 
 .newsitem:hover {
-    background-color: var(--middle-background-light);
+    background-color: var(--color-hover);
 }
 
 .source {
@@ -36,7 +33,7 @@
     font-size: var(--font-xlarge);
     text-transform: capitalize;
     font-weight: var(--font-weight-bold);
-    color: var(--chart-teal);
+    color: var(--color-highlight);
     width: 70%;
     min-width: 0;
     text-overflow: ellipsis;
@@ -55,8 +52,7 @@
 }
 
 .summary {
-    font-size: var(--font-large);
-    color: var(--text-grey);
+    font-size: var(--font-large);    
     overflow: hidden;
     text-overflow: ellipsis;
     display: -webkit-box;

--- a/packages/stockflux-news/src/index.css
+++ b/packages/stockflux-news/src/index.css
@@ -1,5 +1,6 @@
 * {
   box-sizing: border-box;
+  color: var(--text-color);
 }
 
 body {
@@ -11,7 +12,8 @@ body {
 #root {
   height: 100%;
   --header-height: 60px;
-  --titlebar-height: 35px;
-  --newsitem-height: 150px;
+  --tabbar-height: 36px;
+  --titlebar-height: 28px;
+  --newsitem-height: 143px;
   --no-article-height: 30px;
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49903895/68035783-3ed97280-fcbc-11e9-8056-47d18d39ba3b.png)

Update news to fit in with new UX standards.
- Colours updated to new standards
- Title bar matches watch list title bar.
- Placeholder for news 'tabs'. 