### PR TITLE
UX - Change existing windows to new colours

### DIFF
--- a/packages/stockflux-bitflux/src/assets/styles/variables.css
+++ b/packages/stockflux-bitflux/src/assets/styles/variables.css
@@ -1,8 +1,8 @@
 :root { 
---dark-background: #1A212A;
---chart-teal: #37D8BC;
+--dark-background: var(--window-background-color);
+--chart-teal: var(--color-highlight);
 --chart-fade: #307A71;
---text-grey: #AEB1B5;
+--text-grey: var(--text-color);
 --primary-dark-blue: var(--dark-background);
 --secondary-orange: var(--chart-teal);
 --secondary-grey: var(--chart-teal);
@@ -85,12 +85,12 @@
 
 --navigator-height: 100px;
 --navigator-bottom-margin-from-javascript: 40px;
---navigator-extent-colour: var(--secondary-orange);
+--navigator-extent-colour: var(--chart-teal);
 --navigator-colour: var(--primary-blue);
---navigator-background-colour: var(--secondary-dark-blue);
+--navigator-background-colour: var(--window-background-color);
 --navigator-background-stroke-width: 1px;
 --navigator-stroke: 1px;
---navigator-stroke-colour: var(--primary-white);
+--navigator-stroke-colour: var(--chart-teal);
 --navigator-selection-border-colour: var(--primary-white);
 
 --mask-transparent: var(--primary-black);

--- a/packages/stockflux-chart/src/styles/app.css
+++ b/packages/stockflux-chart/src/styles/app.css
@@ -44,7 +44,7 @@ body {
 }
 
 #showcase-title {
-    color: var(--chart-teal);
+    color: var(--color-highlight);
     position: relative;
     top: 5px;
     left: 25px;
@@ -73,7 +73,7 @@ body {
 }
 
 .chart-nav-icon svg {
-    fill: var(--chart-teal);
+    fill: var(--color-highlight);
     padding-right: 10px;
     height: 20px;
     width: 30px;
@@ -82,7 +82,7 @@ body {
 }
 
 .chart-nav-icon:not(.icon-disabled):hover svg {
-    fill: var(--chart-teal-lighter);
+    fill: var(--color-highlight);
 }
 
 .chart-nav-icon.icon-disabled svg {

--- a/packages/stockflux-components/src/index.css
+++ b/packages/stockflux-components/src/index.css
@@ -78,26 +78,26 @@
 
   
   /* Deprecated Style Colours  */
-  --text-grey-darkest: #626569;
-  --text-grey-darker: #7b7e82;
-  --text-grey-dark: #95989c;
-  --text-grey: #aeb1b5;
-  --text-grey-light: #c8cbcf;
-  --text-grey-lighter: #e1e4e8;
+  --text-grey-darkest: var(--text-color);
+  --text-grey-darker: var(--text-color);
+  --text-grey-dark: var(--text-color);
+  --text-grey: var(--text-color);
+  --text-grey-light: var(--text-color);
+  --text-grey-lighter: var(--text-color);
 
-  --text-teal: #307a71;
-  --text-teal-light: #37d8bc;
+  --text-teal: var(--color-highlight);
+  --text-teal-light: var(--color-highlight);
 
   --lightest-background: #79818b;
   --lighter-background: #606872;
   --light-background: #464e58;
 
-  --middle-background: #28313d;
-  --middle-background-light: #424b57;
-  --middle-background-lighter: #5b6470;
+  --middle-background: var(--window-background-color);
+  --middle-background-light: var(--color-hover);
+  --middle-background-lighter: var(--window-divider);
 
-  --dark-background: #1a212a;
+  --dark-background: var(--window-background-color);
 
-  --chart-teal: #37d8bc;
-  --chart-teal-lighter: #51f2d6;  
+  --chart-teal: var(--color-highlight);
+  --chart-teal-lighter: var(--color-highlight);  
 }


### PR DESCRIPTION
Change existing windows to use the same colours as the new UX design. Contains no layout or behaviour changes.
Windows modified
- Chart
- News
- Launcher
- Popup Window
![Recoloured-Windows](https://user-images.githubusercontent.com/49903895/68119313-4a19e180-fefa-11e9-8020-8dedd9e1a933.PNG)
