### PR TITLE
add confirmClose option to titlebar

### DIFF
--- a/packages/stockflux-components/src/components/Titlebar/Titlebar.js
+++ b/packages/stockflux-components/src/components/Titlebar/Titlebar.js
@@ -5,10 +5,11 @@ import { OpenfinApiHelpers } from 'stockflux-core';
 import CloseIcon from '../icons/close.svg';
 import MinimizeIcon from '../icons/minimize.svg';
 import LinkIcon from '../icons/link.svg';
+import ConfirmationWindow from '../popups/ConfirmationWindow';
 
 import './Titlebar.css';
 
-export default ({ title }) => {
+export default ({ title, confirmClose }) => {
   const isDocked = useDocked();
 
   const onMinimizeClick = useCallback(async () => {
@@ -43,9 +44,21 @@ export default ({ title }) => {
         <div className="header-icon" onClick={onMinimizeClick} title="Minimize">
           <MinimizeIcon />
         </div>
-        <div className="header-icon" onClick={onCloseClick} title="Close">
-          <CloseIcon />
-        </div>
+        {!confirmClose && (
+          <div className="header-icon" onClick={onCloseClick} title="Close">
+            <CloseIcon />
+          </div>
+        )}
+        {confirmClose && (
+          <div className="header-icon">
+            <ConfirmationWindow
+              message="This will close all related windows. Do you wish to continue?"
+              onConfirm={onCloseClick}
+            >
+              <CloseIcon />
+            </ConfirmationWindow>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/packages/stockflux-watchlist/public/child-window.html
+++ b/packages/stockflux-watchlist/public/child-window.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </body>
+</html>

--- a/packages/stockflux-watchlist/public/childWindow.css
+++ b/packages/stockflux-watchlist/public/childWindow.css
@@ -1,0 +1,59 @@
+body {
+  overflow-x: hidden;
+  height: inherit;
+}
+
+div#root {
+  height:100vh;
+  flex: 1 1 auto;
+  overflow:hidden;
+}
+
+div.scrollWrapperY > p {
+  text-align: center;
+  color: var(--text-grey-light);
+  padding: 170px 50px;
+  font-weight: var(--font-weight-bold);
+  letter-spacing: 0.2px;
+  margin: 0;
+}
+
+.spinner {
+  position: relative;
+  top:calc(50vh - var(--search-input-height))
+}
+
+.card {
+  padding: var(--padding-medium);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--clr-divider-light);
+}
+
+.card p {
+  cursor: default;
+  margin: var(--margin-medium);
+}
+
+div#actions {
+  float: right;
+  margin: 0 var(--margin-small);
+  display: inherit;
+}
+
+.card:hover {
+  background-color: var(--dark-background);
+}
+
+.name {
+  letter-spacing: 0.5px;
+  font-weight: var(--font-weight-bold);
+  color: var(--text-teal-light);
+}
+.symbol {
+  letter-spacing: 1px;
+  font-size: var(--font-xlarge);
+  font-weight: var(--font-weight-bolder);
+  color: var(--text-grey-lighter);
+}

--- a/packages/stockflux-watchlist/public/popupWindow.css
+++ b/packages/stockflux-watchlist/public/popupWindow.css
@@ -1,0 +1,23 @@
+body {
+    overflow: hidden;
+    padding: 4vh 4vw;
+    border:var(--border);
+    box-sizing: border-box;
+}
+.popup{
+    color:var(--text-grey-lighter);        
+}
+
+.popup-message{
+    text-align: center;
+    font-size: var(--font-large);
+}
+
+.popup-options {
+    text-align: right;
+}
+
+.popup-options button {
+    color:var(--text-teal-light);
+    border-color:var(--text-teal-light);
+}


### PR DESCRIPTION
Add a new parameter to the title bar options which will allow for close confirmation to be applied. 
`<Components.Titlebarr confirmClose={bool}>` can be used to toggle a confirmation dialog on close of a window. If the parameter is omitted or false no dialog is shown and windows close automatically. 

In order for popups to work correctly, the `.html` and `.css` files for the popup need to be included in the project which this is being used. 