### PR TITLE
Fix minimise and close to work with the whole bounding box area

### DIFF
--- a/packages/stockflux-components/src/components/Titlebar/Titlebar.css
+++ b/packages/stockflux-components/src/components/Titlebar/Titlebar.css
@@ -31,7 +31,6 @@
 }
 
 .header-icon {
-    display: inline-block;    
     cursor: pointer;
     padding:3px;
 }

--- a/packages/stockflux-components/src/components/Titlebar/Titlebar.js
+++ b/packages/stockflux-components/src/components/Titlebar/Titlebar.js
@@ -50,12 +50,14 @@ export default ({ title, confirmClose }) => {
           </div>
         )}
         {confirmClose && (
-          <div className="header-icon">
+          <div>
             <ConfirmationWindow
               message="This will close all related windows. Do you wish to continue?"
               onConfirm={onCloseClick}
             >
-              <CloseIcon />
+              <div className="header-icon">
+                <CloseIcon />
+              </div>
             </ConfirmationWindow>
           </div>
         )}

--- a/packages/stockflux-launcher/src/App.css
+++ b/packages/stockflux-launcher/src/App.css
@@ -65,9 +65,6 @@ html {
 
 .header-icon {
   color: var(--text-color);
-  display: inline-block;    
-  cursor: pointer;
-  padding: 8px;
   z-index: 1;
 }
 


### PR DESCRIPTION
Issue mentioned by @SL-SWoods: when clicking the minimise or close on the titlebar, you have to click the icon itself to get the onClick to fire. The highlighted bounding box is not interactive. 

This problem was being caused by the use of `display: inline-block` on the styles. 

* Removed `inline-block` and repeated style tags on launcher
* Make sure click works with bounding box with the `ConfirmationWindow` by moving the style to a div within the window