### PR TITLE
use dynamic positioning for popup window

### DIFF
--- a/packages/stockflux-components/src/components/popups/PopupWindow.js
+++ b/packages/stockflux-components/src/components/popups/PopupWindow.js
@@ -1,6 +1,9 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import DialogButton from '../buttons/dialog-button/DialogButton';
 import { useChildWindow } from 'openfin-react-hooks';
+import getUndockedPosition from './getUndockedPosition';
+
+const windowSize = { height: 145, width: 270 };
 
 const PopupWindow = ({ message, options, children }) => {
   const [showPopup, setShowPopup] = useState(false);
@@ -17,19 +20,22 @@ const PopupWindow = ({ message, options, children }) => {
   });
 
   const launchChildWindow = useCallback(() => {
-    childWindow.launch({
-      name: 'popup-window',
-      url: 'child-window.html',
-      frame: false,
-      autoShow: true,
-      defaultCentered: true,
-      saveWindowState: false,
-      showTaskbarIcon: false,
-      resizable: false,
-      waitForPageLoad: true,
-      alwaysOnTop: true,
-      defaultWidth: 270,
-      defaultHeight: 145
+    getUndockedPosition({ windowSize }).then(position => {
+      childWindow.launch({
+        name: 'popup-window',
+        url: 'child-window.html',
+        frame: false,
+        autoShow: true,
+        defaultTop: position.top,
+        defaultLeft: position.left,
+        saveWindowState: false,
+        showTaskbarIcon: false,
+        resizable: false,
+        waitForPageLoad: true,
+        alwaysOnTop: true,
+        defaultWidth: windowSize.width,
+        defaultHeight: windowSize.height
+      });
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/packages/stockflux-components/src/components/popups/getUndockedPosition.js
+++ b/packages/stockflux-components/src/components/popups/getUndockedPosition.js
@@ -1,0 +1,122 @@
+import { OpenfinApiHelpers } from 'stockflux-core';
+
+async function getBounds() {
+  let bounds = await OpenfinApiHelpers.getCurrentWindowSync().getBounds();
+  return bounds;
+}
+
+async function getMonitorInfo() {
+  let monitorInfo = await OpenfinApiHelpers.getMonitorInfo();
+  return monitorInfo;
+}
+
+function boundsCheck(bounds, screen, primaryCheck) {
+  if (primaryCheck) {
+    const leftInBounds =
+      bounds.left >= screen.left && bounds.left < screen.right;
+    const topInBounds = bounds.top >= screen.top && bounds.top < screen.bottom;
+
+    return leftInBounds && topInBounds;
+  } else {
+    const rightInBounds =
+      bounds.right >= screen.left && bounds.right < screen.right;
+    const bottomInBounds =
+      bounds.bottom >= screen.top && bounds.bottom < screen.bottom;
+
+    return rightInBounds && bottomInBounds;
+  }
+}
+
+function getMiddleScreenPosition(screen, size) {
+  let amount = screen.left + screen.right;
+  let midpoint = amount / 2;
+  return Math.ceil(midpoint - size / 2);
+}
+
+function getCenterScreenPosition(screen, size) {
+  let amount = screen.top + screen.bottom;
+  let midpoint = amount / 2;
+  return Math.ceil(midpoint - size / 2);
+}
+
+function getUndockPosition(
+  bounds,
+  primaryMonitorRect,
+  nonPrimaryMonitors,
+  isInMonitorBool,
+  left,
+  normalBounds,
+  windowSize
+) {
+  isInMonitorBool = boundsCheck(bounds, primaryMonitorRect, normalBounds);
+  left = bounds.left;
+  let top = bounds.top;
+
+  if (isInMonitorBool) {
+    left = getMiddleScreenPosition(primaryMonitorRect, windowSize.width);
+    top = getCenterScreenPosition(primaryMonitorRect, windowSize.height);
+  } else {
+    do {
+      for (const nonPrimaryMonitor of nonPrimaryMonitors) {
+        isInMonitorBool = boundsCheck(
+          bounds,
+          nonPrimaryMonitor.monitorRect,
+          normalBounds
+        );
+        if (isInMonitorBool) {
+          left = getMiddleScreenPosition(
+            nonPrimaryMonitor.monitorRect,
+            windowSize.width
+          );
+          top = getCenterScreenPosition(
+            nonPrimaryMonitor.monitorRect,
+            windowSize.height
+          );
+        }
+      }
+      if (!isInMonitorBool) break;
+    } while (!isInMonitorBool);
+  }
+
+  return { isInMonitorBool, left, top };
+}
+
+export default ({ windowSize = { height: 0, width: 0 } }) => {
+  return getBounds().then(bounds => {
+    return getMonitorInfo().then(monitor => {
+      const nonPrimaryMonitors = monitor.nonPrimaryMonitors;
+      const primaryMonitorRect = monitor.primaryMonitor.monitorRect;
+
+      let isInMonitorBool = false;
+      let left = bounds.left;
+
+      // Check if launcher is in window using left/top checks
+      let resultNormalBounds = getUndockPosition(
+        bounds,
+        primaryMonitorRect,
+        nonPrimaryMonitors,
+        isInMonitorBool,
+        left,
+        true,
+        windowSize
+      );
+
+      if (resultNormalBounds.isInMonitorBool) {
+        return { left: resultNormalBounds.left, top: resultNormalBounds.top };
+      }
+
+      // Check if launcher is in window using right/bottom checks
+      let nonNormalBounds = getUndockPosition(
+        bounds,
+        primaryMonitorRect,
+        nonPrimaryMonitors,
+        isInMonitorBool,
+        left,
+        false,
+        windowSize
+      );
+
+      return { left: nonNormalBounds.left, top: nonNormalBounds.top };
+    });
+  });
+};


### PR DESCRIPTION
Remove `defaultCentered: true` from popup window positioning, due to this only working on a users primary monitor (openfin [spec](https://cdn.openfin.co/docs/javascript/stable/Window.html#~options) ).
Now using a openfin.window to calculate which monitor the calling window is on, and uses that monitor to centre the popup dialog. 