### PR TITLE
add initial unit test for watch list Reducer

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "chart:launch-appd": "cd packages/stockflux-chart && npm run launch-appd",
     "launcher:launch-appd": "cd packages/stockflux-launcher && npm run launch-appd",
     "news:launch-appd": "cd packages/stockflux-news && npm run launch-appd",
-    "watchlist:launch-appd": "cd packages/stockflux-watchlist && npm run launch-appd"
+    "watchlist:launch-appd": "cd packages/stockflux-watchlist && npm run launch-appd",
+    "watchlist:test": "cd packages/stockflux-watchlist && npm run test"
   }
 }

--- a/packages/stockflux-watchlist/package.json
+++ b/packages/stockflux-watchlist/package.json
@@ -24,7 +24,7 @@
     "launch": "openfin --launch --config ./public/app.dev.json",
     "launch-appd": "openfin --launch --config http://localhost:3000/api/apps/v1/stockflux-watchlist/app.json",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --watchAll=false",
     "eject": "react-scripts eject"
   },
   "browserslist": [

--- a/packages/stockflux-watchlist/src/reducers/open-apps/OpenApps.js
+++ b/packages/stockflux-watchlist/src/reducers/open-apps/OpenApps.js
@@ -20,6 +20,6 @@ export default (state, { type, payload }) => {
     case ActionType.RESET:
       return initialState;
     default:
-      throw new Error();
+      return state;
   }
 };

--- a/packages/stockflux-watchlist/src/reducers/open-apps/OpenApps.test.js
+++ b/packages/stockflux-watchlist/src/reducers/open-apps/OpenApps.test.js
@@ -1,0 +1,37 @@
+import reducer, { initialState } from './OpenApps';
+import actions from './Action';
+describe('Action Reducer', () => {
+  it('Should return inital state when given an unknown action', () => {
+    const newState = reducer(initialState, {});
+    expect(newState).toEqual(initialState);
+  });
+
+  it('Should return inital state when given a reset action', () => {
+    const newState = reducer(initialState, { type: actions.RESET });
+    expect(newState).toEqual(initialState);
+  });
+
+  it('Should update news value with payload', () => {
+    const newState = reducer(initialState, {
+      type: actions.SET_NEWS_WINDOW,
+      payload: 'Window Payload'
+    });
+    const expectedState = {
+      news: 'Window Payload',
+      chart: false
+    };
+    expect(newState).toEqual(expectedState);
+  });
+
+  it('Should update chart value with payload', () => {
+    const newState = reducer(initialState, {
+      type: actions.SET_CHART_WINDOW,
+      payload: 'Window Payload'
+    });
+    const expectedState = {
+      chart: 'Window Payload',
+      news: false
+    };
+    expect(newState).toEqual(expectedState);
+  });
+});


### PR DESCRIPTION
Add unit test for reducers within stockflux-watchlist.

New commands added to `package.json`
`npm run watchlist:test` - run tests for watchlist. 
