### PR TITLE
allow use of extra apps in the launcher

### DIFF
--- a/developer-proxy/readMe.md
+++ b/developer-proxy/readMe.md
@@ -1,0 +1,43 @@
+# Developer Proxy
+
+Use of the developer proxy allows you to develop locally in reguards to each seperate app. This can be ran be using the command `npm start` with `./developer-proxy` directory. 
+
+# App Directory
+To modify the app directory to use the local proxy, modify the file `./src/static/apps.json` new stockflux or external apps can be added in for example this is the addition for a Giant Machines Watchlist
+```json
+{
+    "images": [],
+    "intents": [
+      {
+        "name": "WatchlistAdd"
+      },
+      {
+        "name": "WatchlistView"
+      }
+    ],
+    "contactEmail": "contact@giantmachines.com",
+    "manifest": "https://stockflux.scottlogic.com/api/apps/v1/giantmachines-watchlist/app.json",
+    "manifestType": "openfin",
+    "description": "Giant Machines Watchlist",
+    "title": "Watchlist",
+    "icons": [
+      {
+        "icon": "https://stockflux.scottlogic.com/artifacts/giantmachines-watchlist/favicon.ico"
+      },
+      {
+        "icon": "https://stockflux.scottlogic.com/artifacts/giantmachines-watchlist/launcher.png"
+      }
+    ],
+    "supportEmail": "contact@giantmachines.com",
+    "customConfig": {
+      "showInLauncher": true,
+      "launcherIntent": "viewWatchlist"
+    },
+    "appId": "giantmachines-watchlist",
+    "name": "giantmachines-watchlist",
+    "publisher": "Giant Machines"
+  }
+  ```
+  
+  The `showInLauncher` value is the boolean option which allows a new option to appear in the Launcher bar. This needs to be set to `true`.
+  `description` will be the text display which is shown in the launcher menu, and can be customised to change the menu option name. 

--- a/developer-proxy/readMe.md
+++ b/developer-proxy/readMe.md
@@ -1,6 +1,6 @@
 # Developer Proxy
 
-Use of the developer proxy allows you to develop locally in reguards to each seperate app. This can be ran be using the command `npm start` with `./developer-proxy` directory. 
+Use of the developer proxy allows you to develop locally in reguards to each seperate app. This can be ran be using the command `npm run proxy`. 
 
 # App Directory
 To modify the app directory to use the local proxy, modify the file `./src/static/apps.json` new stockflux or external apps can be added in for example this is the addition for a Giant Machines Watchlist

--- a/developer-proxy/src/static/apps.json
+++ b/developer-proxy/src/static/apps.json
@@ -139,7 +139,7 @@
     "contactEmail": "contact@giantmachines.com",
     "manifest": "https://stockflux.scottlogic.com/api/apps/v1/giantmachines-watchlist/app.json",
     "manifestType": "openfin",
-    "description": "Giant Machines Watchlist app",
+    "description": "Giant Machines Watchlist",
     "title": "Watchlist",
     "icons": [
       {

--- a/packages/stockflux-components/src/components/buttons/borderless-buttons/app-shortcuts/External.js
+++ b/packages/stockflux-components/src/components/buttons/borderless-buttons/app-shortcuts/External.js
@@ -2,25 +2,13 @@ import React from 'react';
 import { Launchers } from 'stockflux-core';
 import RoundButton from '../../round-button/RoundButton';
 
-export default ({ manifest, small }) => {
-  if (small) {
-    return (
-      <RoundButton
-        className="shortcut external"
-        onClick={() => Launchers.launchChildWindow(manifest)}
-        small={small}
-      >
-        {manifest.description}
-      </RoundButton>
-    );
-  } else
-    return (
-      <RoundButton
-        className="shortcut external"
-        onClick={() => Launchers.launchChildWindow(manifest)}
-        small={small}
-      >
-        {manifest.description}
-      </RoundButton>
-    );
+export default ({ manifest }) => {
+  return (
+    <RoundButton
+      className="shortcut external"
+      onClick={() => Launchers.launchChildWindow(manifest)}
+    >
+      {manifest.description}
+    </RoundButton>
+  );
 };

--- a/packages/stockflux-components/src/components/buttons/borderless-buttons/app-shortcuts/External.js
+++ b/packages/stockflux-components/src/components/buttons/borderless-buttons/app-shortcuts/External.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Launchers } from 'stockflux-core';
+import RoundButton from '../../round-button/RoundButton';
+
+export default ({ manifest, small }) => {
+  if (small) {
+    return (
+      <RoundButton
+        className="shortcut external"
+        onClick={() => Launchers.launchChildWindow(manifest)}
+        small={small}
+      >
+        {manifest.description}
+      </RoundButton>
+    );
+  } else
+    return (
+      <RoundButton
+        className="shortcut external"
+        onClick={() => Launchers.launchChildWindow(manifest)}
+        small={small}
+      >
+        {manifest.description}
+      </RoundButton>
+    );
+};

--- a/packages/stockflux-components/src/components/buttons/round-button/RoundButton.css
+++ b/packages/stockflux-components/src/components/buttons/round-button/RoundButton.css
@@ -45,3 +45,9 @@
 .round:not(:disabled):active {
   background-color: var(--middle-background-lighter);
 }
+
+.external {
+  width: 76px;
+  height:62px;
+  overflow: hidden;
+}

--- a/packages/stockflux-components/src/index.js
+++ b/packages/stockflux-components/src/index.js
@@ -6,6 +6,7 @@ import Borderless from './components/buttons/borderless-button/BorderlessButton'
 import Chart from './components/buttons/borderless-buttons/app-shortcuts/Chart';
 import News from './components/buttons/borderless-buttons/app-shortcuts/News';
 import Watchlist from './components/buttons/borderless-buttons/app-shortcuts/Watchlist';
+import External from './components/buttons/borderless-buttons/app-shortcuts/External';
 import Close from './components/buttons/borderless-buttons/Close';
 
 import LeftIcon from './components/glyphs/launcher/left.svg';
@@ -47,7 +48,8 @@ export default {
     Chart,
     News,
     Watchlist,
-    Close
+    Close,
+    External
   },
   Icons: {
     Small: {

--- a/packages/stockflux-launcher/src/App.css
+++ b/packages/stockflux-launcher/src/App.css
@@ -66,6 +66,7 @@ body {
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
+  flex-wrap: nowrap;
   height: 60px;
 }
 

--- a/packages/stockflux-launcher/src/app-shortcuts/AppShortcuts.js
+++ b/packages/stockflux-launcher/src/app-shortcuts/AppShortcuts.js
@@ -7,7 +7,7 @@ export default () => {
   const [apps, setApps] = useState([]);
 
   useEffect(() => {
-    OpenfinApiHelpers.getStockFluxApps()
+    OpenfinApiHelpers.getAllApps()
       .then(setApps)
       .catch(console.error);
   }, []);
@@ -36,6 +36,23 @@ export default () => {
               name="Tesla"
               small={false}
             />
+          );
+        })}
+      {apps
+        .filter(
+          app =>
+            app.customConfig !== undefined &&
+            app.customConfig.showInLauncher &&
+            app.appId.indexOf('stockflux-') === -1
+        )
+        .map(app => {
+          return (
+            <Components.Shortcuts.External
+              key={app.appId}
+              className="shortcut"
+              manifest={app}
+              small={false}
+            ></Components.Shortcuts.External>
           );
         })}
     </div>


### PR DESCRIPTION
Modify the launcher to allow multiple apps to show on the launcher.
Includes ReadMe file within `developer-proxy` with instructions on how to add new options to the list. 